### PR TITLE
Restore read_excel functionality for pstools

### DIFF
--- a/pstools/docs/ps-generate.md
+++ b/pstools/docs/ps-generate.md
@@ -12,7 +12,7 @@ Use the tool by running the Python script and passing both an existing prescale
 table and a given L1 menu (see example below).
 
 ```
-python psgenerate.py PStable.xlsx L1Menu.xml
+python ps-generate.py PStable.xlsx L1Menu.xml
 ```
 
 ### Download files on-the-fly
@@ -21,7 +21,7 @@ It is also possible to pass URLs instead of the local filepaths of a prescale
 table or an XML menu, as the following example demonstrates.
 
 ```
-python psgenerate.py https://github.com/cms-l1-dpg/L1Menu2018/raw/master/official/PrescaleTables/PrescaleTable-1_L1Menu_Collisions2018_v2_1_0.xlsx https://raw.githubusercontent.com/cms-l1-dpg/L1Menu2018/master/official/XMLs/L1Menu_CollisionsHeavyIons2018_v4_0_0.xml
+python ps-generate.py https://github.com/cms-l1-dpg/L1Menu2018/raw/master/official/PrescaleTables/PrescaleTable-1_L1Menu_Collisions2018_v2_1_0.xlsx https://raw.githubusercontent.com/cms-l1-dpg/L1Menu2018/master/official/XMLs/L1Menu_CollisionsHeavyIons2018_v4_0_0.xml
 ```
 
 The files are stored in temporary directories and are

--- a/pstools/psutils/psio.py
+++ b/pstools/psutils/psio.py
@@ -59,7 +59,7 @@ def read_prescale_table(filepath: Any) -> pd.DataFrame:
         else:
             print('\nFile downloaded: {}'.format(filepath))
 
-    data = pd.read_excel(filepath, convert_float=True)
+    data = pd.read_excel(filepath, convert_float=True, engine="openpyxl")
     return data
 
 

--- a/pstools/setup.sh
+++ b/pstools/setup.sh
@@ -13,6 +13,15 @@ echo "Activating virtual environment..."
 . env/bin/activate
 
 echo ""
+echo "Updating pip..."
+pip install -U pip
+if [ $? -ne 0 ]; then
+	echo "Error updating pip."
+	exit 1
+fi
+
+
+echo ""
 echo "Installing requirements..."
 pip install -r requirements.txt
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Recent changes in Pandas broke the pstools read_excel calls
(https://pandas.pydata.org/docs/whatsnew/v1.2.0.html).
Invoking the openpyxl engine seems to fix the problem.

This addresses #18.

Other changes:
- add pip update to the setup workflow
- fix a typo in the docs