### PR TITLE
Bug fixes for upt invariant mass inclusions, as well as the comb over…

### DIFF
--- a/rate-estimation/menu2lib/menu2lib.py
+++ b/rate-estimation/menu2lib/menu2lib.py
@@ -144,7 +144,7 @@ def hasCorrelationCuts(condition):
   requireDeltaEta = False
 
   for cut in condition.getCuts():
-    if cut.getCutType() in (tmEventSetup.DeltaEta, tmEventSetup.OvRmDeltaR, tmEventSetup.Mass,
+    if cut.getCutType() in (tmEventSetup.DeltaEta, tmEventSetup.OvRmDeltaR, tmEventSetup.Mass, tmEventSetup.MassUpt,
                             tmEventSetup.OvRmDeltaEta, tmEventSetup.DeltaR):
       requireDeltaEta = True
 

--- a/rate-estimation/menu2lib/templates/CaloCaloCorrelationTemplate.cc
+++ b/rate-estimation/menu2lib/templates/CaloCaloCorrelationTemplate.cc
@@ -8,6 +8,8 @@
 {% set objects = cond.getObjects() %}
 {% if overlap_removal %}
   {% set reference = objects[objects|length -1] %}
+  {% set etaScaleRef = scaleMap | getScale(reference, tmGrammar.ETA) %}
+  {% set nEtaBits = etaScaleRef.getNbits() %}  
 {% endif %}
 {% set nObjects = 2 %}
 {% set objects = objects[0] | sortObjects(objects[1]) %}
@@ -20,6 +22,7 @@
 
 {% set etaScale1 = scaleMap | getScale(objects[1], tmGrammar.ETA) %}
 {% set nEtaBits1 = etaScale1.getNbits() %}
+
 {# assume phiScale is the same for calo objects #}
 
 {% set LUTS = scaleMap | getLookUpTable(objects[0], objects[1]) %}

--- a/rate-estimation/menu2lib/templates/MenuTemplate.cc
+++ b/rate-estimation/menu2lib/templates/MenuTemplate.cc
@@ -233,7 +233,7 @@ PermutationFactory::cache_t PermutationFactory::cache_ = {};
 // generate conditions
 {% for name, cond in menu.getConditionMapPtr().items() %}
   {%- set overlap_removal = 0 -%}
-  {%- if cond.getType() in (tmEventSetup.CaloCaloCorrelationOvRm,
+  {%- if cond.getType() in (tmEventSetup.CaloCaloCorrelationOvRm, tmEventSetup.DoubleJetOvRm, tmEventSetup.DoubleTauOvRm,
                             tmEventSetup.InvariantMassOvRm) %}
     {% set overlap_removal = 1 %}
   {% endif -%}
@@ -263,7 +263,7 @@ PermutationFactory::cache_t PermutationFactory::cache_ = {};
   {% elif cond.getType() in (tmEventSetup.CaloMuonCorrelation, ) %}
     {% include 'CaloMuonCorrelationTemplate.cc' %}
 
-  {% elif cond.getType() in (tmEventSetup.CaloCaloCorrelation, tmEventSetup.CaloCaloCorrelationOvRm) %}
+  {% elif cond.getType() in (tmEventSetup.CaloCaloCorrelation, tmEventSetup.CaloCaloCorrelationOvRm, tmEventSetup.DoubleJetOvRm, tmEventSetup.DoubleTauOvRm) %}
     {% include 'CaloCaloCorrelationTemplate.cc' %}
 
   {% elif cond.getType() in (tmEventSetup.InvariantMass, tmEventSetup.InvariantMassOvRm) %}


### PR DESCRIPTION
…lap removal (with and without invariant mass). Now allows to have eta selection for the reference object. Only for CaloCalo so far.

Please note that in past the upt invariant mass broke down. Now fixed.

We also fixed the comb overlap removal (with and without invariant mass). Previously it broke down due to the undefined nEtaBits, now included. Please note that this PR includes only for CaloCalo cases, we need to check if other cases must be fixed in a similar manner!