### PR TITLE
Add 3-body invariant mass

### DIFF
--- a/rate-estimation/menu2lib/templates/MenuTemplate.cc
+++ b/rate-estimation/menu2lib/templates/MenuTemplate.cc
@@ -295,8 +295,9 @@ PermutationFactory::cache_t PermutationFactory::cache_ = {};
 
   {% elif cond.getType() == tmEventSetup.InvariantMass3 %}
     {% set objects = cond.getObjects() %}
-    {% set combination = tmEventSetup.getObjectCombination(objects[0].getType(), objects[1].getType()) %}
-    {% if combination == tmEventSetup.MuonMuonCombination %}
+    {% set combination01 = tmEventSetup.getObjectCombination(objects[0].getType(), objects[1].getType()) %}
+    {% set combination02 = tmEventSetup.getObjectCombination(objects[0].getType(), objects[2].getType()) %}
+    {% if combination01 == tmEventSetup.MuonMuonCombination and combination02 == tmEventSetup.MuonMuonCombination %}
       {% include 'Muon3CorrelationTemplate.cc' %}
     {% endif %}
 

--- a/rate-estimation/menu2lib/templates/MenuTemplate.cc
+++ b/rate-estimation/menu2lib/templates/MenuTemplate.cc
@@ -293,6 +293,13 @@ PermutationFactory::cache_t PermutationFactory::cache_ = {};
       err> unsupported object combination for mT
     {% endif %}
 
+  {% elif cond.getType() == tmEventSetup.InvariantMass3 %}
+    {% set objects = cond.getObjects() %}
+    {% set combination = tmEventSetup.getObjectCombination(objects[0].getType(), objects[1].getType()) %}
+    {% if combination == tmEventSetup.MuonMuonCombination %}
+      {% include 'Muon3CorrelationTemplate.cc' %}
+    {% endif %}
+
   {% endif -%}
 {% endfor %}
 

--- a/rate-estimation/menu2lib/templates/Muon3CorrelationTemplate.cc
+++ b/rate-estimation/menu2lib/templates/Muon3CorrelationTemplate.cc
@@ -17,10 +17,7 @@
 
 {% set prefix = objects[0] | getPrefix %}
 
-{% set LUTS01 = scaleMap | getLookUpTable(objects[0], objects[1]) %}
-{% set LUTS02 = scaleMap | getLookUpTable(objects[0], objects[2]) %}
-{% set LUTS12 = scaleMap | getLookUpTable(objects[1], objects[2]) %}
-
+{% set LUTS = scaleMap | getLookUpTable(objects[0], objects[1]) %}
 
 {% set iPi = (0.5*(phiScale.getMaximum() - phiScale.getMinimum())/phiScale.getStep()) | int -%}
 
@@ -63,7 +60,7 @@ bool
 {{ macros.getObjectCuts(prefix, 'idx0', objects[0], tmEventSetup, nEtaBits) }}
 {{ macros.getObjectCuts(prefix, 'idx1', objects[1], tmEventSetup, nEtaBits) }}
 {{ macros.getObjectCuts(prefix, 'idx2', objects[2], tmEventSetup, nEtaBits) }}
-{{ macros.getSameTypeCorrelationCuts3(prefix, 'idx0', 'idx1', 'idx2', cond, tmEventSetup, LUTS01, LUTS02, LUTS12, iPi) }}
+{{ macros.getSameTypeCorrelationCuts3(prefix, 'idx0', 'idx1', 'idx2', cond, tmEventSetup, LUTS, iPi) }}
       pass = true;
       break;
     }
@@ -121,7 +118,7 @@ bool
         {% endif %}
         const int idx2 = kk;
 {{ macros.getObjectCuts(prefix, 'idx2', objects[2], tmEventSetup, nEtaBits) }}
-{{ macros.getSameTypeCorrelationCuts3(prefix, 'idx0', 'idx1', 'idx2', cond, tmEventSetup, LUTS01, LUTS02, LUTS12, iPi) }}
+{{ macros.getSameTypeCorrelationCuts3(prefix, 'idx0', 'idx1', 'idx2', cond, tmEventSetup, LUTS, iPi) }}
       pass = true;
       break;
     }

--- a/rate-estimation/menu2lib/templates/Muon3CorrelationTemplate.cc
+++ b/rate-estimation/menu2lib/templates/Muon3CorrelationTemplate.cc
@@ -1,0 +1,136 @@
+{#
+ # @author: Takashi MATSUSHITA
+ #}
+{% block Muon3CorrelationTemplate scoped %}
+
+{% import 'macros.jinja2' as macros %}
+
+{% set objects = cond.getObjects() %}
+{% if overlap_removal %}
+  {% set reference = objects[objects|length -1] %}
+{% endif %}
+{% set nObjects = 3 %}
+
+{% set etaScale = scaleMap | getScale(objects[0], tmGrammar.ETA) %}
+{% set nEtaBits = etaScale.getNbits() %}
+{% set phiScale = scaleMap | getScale(objects[0], tmGrammar.PHI) %}
+
+{% set prefix = objects[0] | getPrefix %}
+
+{% set LUTS01 = scaleMap | getLookUpTable(objects[0], objects[1]) %}
+{% set LUTS02 = scaleMap | getLookUpTable(objects[0], objects[2]) %}
+{% set LUTS12 = scaleMap | getLookUpTable(objects[1], objects[2]) %}
+
+
+{% set iPi = (0.5*(phiScale.getMaximum() - phiScale.getMinimum())/phiScale.getStep()) | int -%}
+
+
+{% if objects[0].getBxOffset() == objects[1].getBxOffset() and objects[1].getBxOffset() == objects[2].getBxOffset() %}
+bool
+{{ cond.getName() }}
+(L1Analysis::L1AnalysisL1UpgradeDataFormat* data)
+{
+{% if overlap_removal %}
+    {{ macros.getReference(reference, tmEventSetup, nEtaBits) }}
+{% endif %}
+  size_t nobj = 0;
+  std::vector<int> candidates;
+  for (size_t ii = 0; ii < data->{{prefix}}Bx.size(); ii++)
+  {
+    if (not (data->{{prefix}}Bx.at(ii) == {{ objects[0].getBxOffset() }})) continue;
+    nobj++;
+{{ macros.checkObjectIndex(objects[0], 'nobj') }} {# same indexing for all objects #}
+{% if overlap_removal %}
+      {{ cond | hasCorrelationCuts() }}
+      {{ macros.removeOverlap(cond, objects[0], 'ii', reference, tmEventSetup, scaleMap, iPi) }}
+{% endif %}
+    candidates.emplace_back(ii);
+  }
+
+  bool pass = false;
+  if (candidates.size() < {{nObjects}}) return pass;
+
+  const auto& combination = CombinationFactory::get(candidates.size(), {{nObjects}});
+  const auto& permutation = PermutationFactory::get({{nObjects}});
+
+  for (const auto& set: combination)
+  {
+    for (const auto& indicies: permutation)
+    {
+      const int idx0 = candidates.at(set.at(indicies.at(0)));
+      const int idx1 = candidates.at(set.at(indicies.at(1)));
+      const int idx2 = candidates.at(set.at(indicies.at(2)));
+{{ macros.getObjectCuts(prefix, 'idx0', objects[0], tmEventSetup, nEtaBits) }}
+{{ macros.getObjectCuts(prefix, 'idx1', objects[1], tmEventSetup, nEtaBits) }}
+{{ macros.getObjectCuts(prefix, 'idx2', objects[2], tmEventSetup, nEtaBits) }}
+{{ macros.getSameTypeCorrelationCuts3(prefix, 'idx0', 'idx1', 'idx2', cond, tmEventSetup, LUTS01, LUTS02, LUTS12, iPi) }}
+      pass = true;
+      break;
+    }
+
+    if (pass) break;
+  }
+
+  return pass;
+}
+
+{% else %}
+bool
+{{ cond.getName() }}
+(L1Analysis::L1AnalysisL1UpgradeDataFormat* data)
+{
+  {% if overlap_removal %}
+    {{ macros.getReference(reference, tmEventSetup, nEtaBits) }}
+  {% endif %}
+  bool pass = false;
+  size_t nobj0 = 0;
+  for (size_t ii = 0; ii < data->{{prefix}}Bx.size(); ii++)
+  {
+    if (not (data->{{prefix}}Bx.at(ii) == {{ objects[0].getBxOffset() }})) continue;
+    nobj0++;
+{{ macros.checkObjectIndex(objects[0], 'nobj0') }}
+    {% if overlap_removal %}
+      {{ cond | hasCorrelationCuts() }}
+      {{ macros.removeOverlap(cond, objects[0], 'ii', reference, tmEventSetup, scaleMap, iPi) }}
+    {% endif %}
+    const int idx0 = ii;
+{{ macros.getObjectCuts(prefix, 'idx0', objects[0], tmEventSetup, nEtaBits) }}
+
+    size_t nobj1 = 0;
+    for (size_t jj = 0; jj < data->{{prefix}}Bx.size(); jj++)
+    {
+      if (not (data->{{prefix}}Bx.at(jj) == {{ objects[1].getBxOffset() }})) continue;
+      nobj1++;
+      {{ macros.checkObjectIndex(objects[1], 'nobj1') }}
+      {% if overlap_removal %}
+        {{ cond | hasCorrelationCuts() }}
+        {{ macros.removeOverlap(cond, objects[1], 'jj', reference, tmEventSetup, scaleMap, iPi) }}
+      {% endif %}
+      const int idx1 = jj;
+{{ macros.getObjectCuts(prefix, 'idx1', objects[1], tmEventSetup, nEtaBits) }}
+
+      size_t nobj2 = 0;
+      for (size_t kk = 0; kk < data->{{prefix}}Bx.size(); kk++)
+      {
+        if (not (data->{{prefix}}Bx.at(kk) == {{ objects[2].getBxOffset() }})) continue;
+        nobj2++;
+        {{ macros.checkObjectIndex(objects[2], 'nobj2') }}
+        {% if overlap_removal %}
+          {{ cond | hasCorrelationCuts() }}
+          {{ macros.removeOverlap(cond, objects[2], 'kk', reference, tmEventSetup, scaleMap, iPi) }}
+        {% endif %}
+        const int idx2 = kk;
+{{ macros.getObjectCuts(prefix, 'idx2', objects[2], tmEventSetup, nEtaBits) }}
+{{ macros.getSameTypeCorrelationCuts3(prefix, 'idx0', 'idx1', 'idx2', cond, tmEventSetup, LUTS01, LUTS02, LUTS12, iPi) }}
+      pass = true;
+      break;
+    }
+    if (pass) break;
+  }
+
+  return pass;
+}
+{% endif %}
+
+{% endblock Muon3CorrelationTemplate %}
+{# eof #}

--- a/rate-estimation/menu2lib/templates/macros.jinja2
+++ b/rate-estimation/menu2lib/templates/macros.jinja2
@@ -279,7 +279,7 @@
 
   {% elif cut.getCutType() == tmEventSetup.Mass %}
     // {{ cut.getMinimum().value | toMass }} <= mass <= {{ cut.getMaximum().value | toMass}}
-    {{ setMass2(prefix, prefix, idx0, idx1, LUTS, iPi, False) }}
+    {{ setMass2(prefix, prefix, idx0, idx1, LUTS, iPi, False, '') }}
     {{ applyFunctionCut('mass2', cut, LUTS.PREC_MASS) }}
 
   {% elif cut.getCutType() == tmEventSetup.MassUpt %}
@@ -341,7 +341,7 @@
 
   {% elif cut.getCutType() == tmEventSetup.Mass %}
     // {{ cut.getMinimum().value | toMass }} <= mass <= {{ cut.getMaximum().value | toMass}}
-    {{ setMass2(prefix0, prefix1, idx0, idx1, LUTS, iPi, False) }}
+    {{ setMass2(prefix0, prefix1, idx0, idx1, LUTS, iPi, False, '') }}
     {{ applyFunctionCut('mass2', cut, LUTS.PREC_MASS) }}
 
   {% endif %}

--- a/rate-estimation/menu2lib/templates/macros.jinja2
+++ b/rate-estimation/menu2lib/templates/macros.jinja2
@@ -47,16 +47,16 @@
 {#
  # set delta phi
  #}
-{% macro setDeltaPhi(prefix0, prefix1, idx0, idx1, LUTS, iPi, useDelta=True) %}
-  int iPhi = {{ getIPhi(prefix0, idx0) }};
+{% macro setDeltaPhi(prefix0, prefix1, idx0, idx1, LUTS, iPi, useDelta=True, ns='') %}
+  int {{ns}}iPhi = {{ getIPhi(prefix0, idx0) }};
   {% if (prefix0 != prefix1) and (prefix1 | isMuon) %}
-    iPhi = {{LUTS.CONV_PHI}}[iPhi];
+    {{ns}}iPhi = {{LUTS.CONV_PHI}}[{{ns}}iPhi];
   {% endif %}
 
-  unsigned int deltaIPhi = abs(iPhi - {{ getIPhi(prefix1, idx1) }});
-  if (deltaIPhi >= {{iPi}}) deltaIPhi = 2*{{iPi}} - deltaIPhi;
+  unsigned int {{ns}}deltaIPhi = abs({{ns}}iPhi - {{ getIPhi(prefix1, idx1) }});
+  if ({{ns}}deltaIPhi >= {{iPi}}) {{ns}}deltaIPhi = 2*{{iPi}} - {{ns}}deltaIPhi;
   {% if useDelta %}
-      const unsigned int deltaPhi = {{LUTS.DPHI}}[deltaIPhi];
+      const unsigned int {{ns}}deltaPhi = {{LUTS.DPHI}}[{{ns}}deltaIPhi];
   {% endif %}
 {% endmacro %}
 
@@ -64,15 +64,15 @@
 {#
  # set delta eta
  #}
-{% macro setDeltaEta(prefix0, prefix1, idx0, idx1, LUTS, useDelta=True) %}
-  iEta = {{ getIEta(prefix0, idx0) }};
+{% macro setDeltaEta(prefix0, prefix1, idx0, idx1, LUTS, useDelta=True, ns='') %}
+  {% if ns %}int {% endif %}{{ns}}iEta = {{ getIEta(prefix0, idx0) }};
   {% if (prefix0 != prefix1) and (prefix1 | isMuon) %}
-    if (iEta < 0) iEta += {{LUTS.ETA_OFFSET}};
-    iEta = {{LUTS.CONV_ETA}}[iEta];
+    if ({{ns}}iEta < 0) {{ns}}iEta += {{LUTS.ETA_OFFSET}};
+    {{ns}}iEta = {{LUTS.CONV_ETA}}[{{ns}}iEta];
   {% endif %}
-  deltaIEta = abs(iEta - {{ getIEta(prefix1, idx1) }});
+  {% if ns %}int {% endif %}{{ns}}deltaIEta = abs({{ns}}iEta - {{ getIEta(prefix1, idx1) }});
   {% if useDelta %}
-    unsigned int deltaEta = {{LUTS.DETA}}[deltaIEta];
+    unsigned int {{ns}}deltaEta = {{LUTS.DETA}}[{{ns}}deltaIEta];
   {% endif %}
 {% endmacro %}
 
@@ -90,28 +90,25 @@
 {#
  # set mass2
  #}
-{%- macro setMass2(prefix0, prefix1, idx0, idx1, LUTS, iPi, useDelta=True) -%}
-    {{ setDeltaEta(prefix0, prefix1, idx0, idx1, LUTS, useDelta) }}
-    {{ setDeltaPhi(prefix0, prefix1, idx0, idx1, LUTS, iPi, useDelta) }}
-    const long long coshDeltaEta = {{LUTS.COSH_DETA}}[deltaIEta];
-    const long long cosDeltaPhi = {{LUTS.COS_DPHI}}[deltaIPhi];
-    const long long pt0 = {{LUTS.ET0}}[data->{{prefix0}}IEt.at({{idx0}})];
-    const long long pt1 = {{LUTS.ET1}}[data->{{prefix1}}IEt.at({{idx1}})];
-    const long long mass2 = pt0 * pt1 * (coshDeltaEta - cosDeltaPhi);
+{%- macro setMass2(prefix0, prefix1, idx0, idx1, LUTS, iPi, useDelta=True, ns='') -%}
+    {{ setDeltaEta(prefix0, prefix1, idx0, idx1, LUTS, useDelta, ns) }}
+    {{ setDeltaPhi(prefix0, prefix1, idx0, idx1, LUTS, iPi, useDelta, ns) }}
+    const long long {{ns}}coshDeltaEta = {{LUTS.COSH_DETA}}[{{ns}}deltaIEta];
+    const long long {{ns}}cosDeltaPhi = {{LUTS.COS_DPHI}}[{{ns}}deltaIPhi];
+    const long long {{ns}}pt0 = {{LUTS.ET0}}[data->{{prefix0}}IEt.at({{idx0}})];
+    const long long {{ns}}pt1 = {{LUTS.ET1}}[data->{{prefix1}}IEt.at({{idx1}})];
+    const long long {{ns}}mass2 = {{ns}}pt0 * {{ns}}pt1 * ({{ns}}coshDeltaEta - {{ns}}cosDeltaPhi);
 {%- endmacro -%}
 
 
 {#
- # set massUpt2
+ # set mass3
  #}
-{%- macro setMassUpt2(prefix0, prefix1, idx0, idx1, LUTS, iPi, useDelta=True) -%}
-    {{ setDeltaEta(prefix0, prefix1, idx0, idx1, LUTS, useDelta) }}
-    {{ setDeltaPhi(prefix0, prefix1, idx0, idx1, LUTS, iPi, useDelta) }}
-    const long long coshDeltaEta = {{LUTS.COSH_DETA}}[deltaIEta];
-    const long long cosDeltaPhi = {{LUTS.COS_DPHI}}[deltaIPhi];
-    const long long upt0 = {{LUTS.UPT0}}[data->{{prefix0}}IEtUnconstrained.at({{idx0}})];
-    const long long upt1 = {{LUTS.UPT1}}[data->{{prefix1}}IEtUnconstrained.at({{idx1}})];
-    const long long mass2 = upt0 * upt1 * (coshDeltaEta - cosDeltaPhi);
+{%- macro setMass3(prefix0, prefix1, prefix2, idx0, idx1, idx2, LUTS01, LUTS02, LUTS12, iPi, useDelta=True) -%}
+    {{ setMass2(prefix0, prefix1, idx0, idx1, LUTS01, iPi, useDelta, 'ab_') }}
+    {{ setMass2(prefix0, prefix2, idx0, idx2, LUTS02, iPi, useDelta, 'ac_') }}
+    {{ setMass2(prefix1, prefix2, idx1, idx2, LUTS12, iPi, useDelta, 'bc_') }}
+    const long long mass3 = ab_mass2 + ac_mass2 + bc_mass2;
 {%- endmacro -%}
 
 
@@ -273,11 +270,6 @@
     {{ setMass2(prefix, prefix, idx0, idx1, LUTS, iPi, False) }}
     {{ applyFunctionCut('mass2', cut, LUTS.PREC_MASS) }}
 
-  {% elif cut.getCutType() == tmEventSetup.MassUpt %}
-    // {{ cut.getMinimum().value | toMass }} <= mass <= {{ cut.getMaximum().value | toMass}}
-    {{ setMassUpt2(prefix, prefix, idx0, idx1, LUTS, iPi, False) }}
-    {{ applyFunctionCut('mass2', cut, LUTS.PREC_MASS) }}
-
   {% elif cut.getCutType() == tmEventSetup.ChargeCorrelation %}
     if (data->{{prefix}}Chg.at({{idx0}}) == 0) continue;  // charge valid bit not set
     if (data->{{prefix}}Chg.at({{idx1}}) == 0) continue;  // charge valid bit not set
@@ -291,6 +283,21 @@
   {% endif %}
   {% endfor %}
 {% endmacro %}
+
+{#
+ # get cuts for correlations of objects with the same type
+ #}
+{% macro getSameTypeCorrelationCuts3(prefix, idx0, idx1, idx2, cond, tmEventSetup, LUTS01, LUTS02, LUTS12, iPi) %}
+  {{ cond | hasCorrelationCuts }}
+  {% for cut in cond.getCuts() %}
+  {% if cut.getCutType() == tmEventSetup.Mass %}
+    // {{ cut.getMinimum().value | toMass }} <= mass <= {{ cut.getMaximum().value | toMass}}
+    {{ setMass3(prefix, prefix, prefix, idx0, idx1, idx2, LUTS01, LUTS02, LUTS12, iPi, False) }}
+    {{ applyFunctionCut('mass3', cut, LUTS01.PREC_MASS) }}
+  {% endif %}
+  {% endfor %}
+{% endmacro %}
+
 
 
 {#
@@ -467,3 +474,4 @@
 {% endmacro %}
 
 {# eof #}
+

--- a/rate-estimation/menu2lib/templates/macros.jinja2
+++ b/rate-estimation/menu2lib/templates/macros.jinja2
@@ -100,6 +100,18 @@
     const long long {{ns}}mass2 = {{ns}}pt0 * {{ns}}pt1 * ({{ns}}coshDeltaEta - {{ns}}cosDeltaPhi);
 {%- endmacro -%}
 
+{#
+ # set massUpt2
+ #}
+{%- macro setMassUpt2(prefix0, prefix1, idx0, idx1, LUTS, iPi, useDelta=True) -%}
+    {{ setDeltaEta(prefix0, prefix1, idx0, idx1, LUTS, useDelta) }}
+    {{ setDeltaPhi(prefix0, prefix1, idx0, idx1, LUTS, iPi, useDelta) }}
+    const long long coshDeltaEta = {{LUTS.COSH_DETA}}[deltaIEta];
+    const long long cosDeltaPhi = {{LUTS.COS_DPHI}}[deltaIPhi];
+    const long long upt0 = {{LUTS.UPT0}}[data->{{prefix0}}IEtUnconstrained.at({{idx0}})];
+    const long long upt1 = {{LUTS.UPT1}}[data->{{prefix1}}IEtUnconstrained.at({{idx1}})];
+    const long long mass2 = upt0 * upt1 * (coshDeltaEta - cosDeltaPhi);
+{%- endmacro -%}
 
 {#
  # set mass3
@@ -268,6 +280,11 @@
   {% elif cut.getCutType() == tmEventSetup.Mass %}
     // {{ cut.getMinimum().value | toMass }} <= mass <= {{ cut.getMaximum().value | toMass}}
     {{ setMass2(prefix, prefix, idx0, idx1, LUTS, iPi, False) }}
+    {{ applyFunctionCut('mass2', cut, LUTS.PREC_MASS) }}
+
+  {% elif cut.getCutType() == tmEventSetup.MassUpt %}
+    // {{ cut.getMinimum().value | toMass }} <= mass <= {{ cut.getMaximum().value | toMass}}
+    {{ setMassUpt2(prefix, prefix, idx0, idx1, LUTS, iPi, False) }}
     {{ applyFunctionCut('mass2', cut, LUTS.PREC_MASS) }}
 
   {% elif cut.getCutType() == tmEventSetup.ChargeCorrelation %}

--- a/rate-estimation/menu2lib/templates/macros.jinja2
+++ b/rate-estimation/menu2lib/templates/macros.jinja2
@@ -116,10 +116,10 @@
 {#
  # set mass3
  #}
-{%- macro setMass3(prefix0, prefix1, prefix2, idx0, idx1, idx2, LUTS01, LUTS02, LUTS12, iPi, useDelta=True) -%}
-    {{ setMass2(prefix0, prefix1, idx0, idx1, LUTS01, iPi, useDelta, 'ab_') }}
-    {{ setMass2(prefix0, prefix2, idx0, idx2, LUTS02, iPi, useDelta, 'ac_') }}
-    {{ setMass2(prefix1, prefix2, idx1, idx2, LUTS12, iPi, useDelta, 'bc_') }}
+{%- macro setMass3(prefix0, prefix1, prefix2, idx0, idx1, idx2, LUTS, iPi, useDelta=True) -%}
+    {{ setMass2(prefix0, prefix1, idx0, idx1, LUTS, iPi, useDelta, 'ab_') }}
+    {{ setMass2(prefix0, prefix2, idx0, idx2, LUTS, iPi, useDelta, 'ac_') }}
+    {{ setMass2(prefix1, prefix2, idx1, idx2, LUTS, iPi, useDelta, 'bc_') }}
     const long long mass3 = ab_mass2 + ac_mass2 + bc_mass2;
 {%- endmacro -%}
 
@@ -304,13 +304,13 @@
 {#
  # get cuts for correlations of objects with the same type
  #}
-{% macro getSameTypeCorrelationCuts3(prefix, idx0, idx1, idx2, cond, tmEventSetup, LUTS01, LUTS02, LUTS12, iPi) %}
+{% macro getSameTypeCorrelationCuts3(prefix, idx0, idx1, idx2, cond, tmEventSetup, LUTS, iPi) %}
   {{ cond | hasCorrelationCuts }}
   {% for cut in cond.getCuts() %}
   {% if cut.getCutType() == tmEventSetup.Mass %}
     // {{ cut.getMinimum().value | toMass }} <= mass <= {{ cut.getMaximum().value | toMass}}
-    {{ setMass3(prefix, prefix, prefix, idx0, idx1, idx2, LUTS01, LUTS02, LUTS12, iPi, False) }}
-    {{ applyFunctionCut('mass3', cut, LUTS01.PREC_MASS) }}
+    {{ setMass3(prefix, prefix, prefix, idx0, idx1, idx2, LUTS, iPi, False) }}
+    {{ applyFunctionCut('mass3', cut, LUTS.PREC_MASS) }}
   {% endif %}
   {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
Based on the macros code from @arnobaer  - thanks for his help! Tested using a seed with 3 muons.

I would like to understand how to deal with precision definition for the mass3 - can we use LUTS01 as I did below [1], or should this be defined differently?

[1] https://github.com/cms-l1-dpg/L1MenuTools/compare/master...jheikkil:bugFixes?expand=1#diff-812f1df4e11f882077929151bd51ec56e39dcf2f7df906a3f9efe5e24afdbc8eR296
