### PR TITLE
Migration to utm 0.9.1

### DIFF
--- a/rate-estimation/configure.sh
+++ b/rate-estimation/configure.sh
@@ -13,6 +13,8 @@ SCRIPT=$SCRIPT_DIR/menu2lib.py
 ENV_DIR=menu2lib.env
 ENV_PYTHON=python3
 
+PIP_OPTIONS="--no-cache-dir"
+
 MENU_FILE=$1
 
 if [ -z "$MENU_FILE" ]; then
@@ -24,8 +26,8 @@ if [ ! -d "$ENV_DIR" ]; then
 	echo "creating virtual environment..."
 	$ENV_PYTHON -m venv $ENV_DIR
 	source $ENV_DIR/bin/activate
-	python -m pip install -U pip
-	python -m pip install -r $SCRIPT_DIR/requirements.txt
+	python -m pip $PIP_OPTIONS install -U pip
+	python -m pip $PIP_OPTIONS install -r $SCRIPT_DIR/requirements.txt
 	deactivate
 	echo "creating virtual environment... done."
 fi

--- a/rate-estimation/menu2lib/menu2lib.py
+++ b/rate-estimation/menu2lib/menu2lib.py
@@ -12,9 +12,9 @@ from jinja2 import Environment, FileSystemLoader
 import tmGrammar
 import tmEventSetup
 
-UTM_VERSION = '0.8.2'
-assert tmGrammar.__version__ == UTM_VERSION, "invalid utm version"
-assert tmEventSetup.__version__ == UTM_VERSION, "invalid utm version"
+UTM_VERSION = '0.9.1'
+assert tmGrammar.__version__ == UTM_VERSION, f"invalid utm version {tmGrammar.__version__}, should be {UTM_VERSION}"
+assert tmEventSetup.__version__ == UTM_VERSION, f"invalid utm version {tmEventSetup.__version__}, should be {UTM_VERSION}"
 
 #
 # constants

--- a/rate-estimation/menu2lib/requirements.txt
+++ b/rate-estimation/menu2lib/requirements.txt
@@ -1,3 +1,3 @@
 jinja2
 requests
-tm-python @ git+https://github.com/cms-l1-globaltrigger/tm-python.git@0.8.2
+tm-python @ git+https://github.com/cms-l1-globaltrigger/tm-python.git@0.9.1


### PR DESCRIPTION
Migration of rate-estimation/menu2lib to utm version 0.9.1 bringing support for hadronic muon shower signals (grammar parser 0.9 required to load new XML files that contain `MUS0`, `MUS1`, `MUSOOT0`, `MUSOOT1` signals).

Nothing to be changed in menu2lib templates.