### PR TITLE
Implement muon showers correctly 

### DIFF
--- a/rate-estimation/menu2lib/menu2lib.py
+++ b/rate-estimation/menu2lib/menu2lib.py
@@ -43,15 +43,6 @@ PREFIX = {
   tmEventSetup.MUSOOT1: 'muonShower'
 }
 
-# Muon showers: Add mapping for event setup types to L1Analysis types;
-# it can be done for Centrality signals, as well
-ANALYSIS_TYPES = {
-  tmEventSetup.MUS0: 'kOneNominal', # how to map these types?
-  tmEventSetup.MUS1: 'kOneTight',
-  tmEventSetup.MUSOOT0: 'kInvalid',
-  tmEventSetup.MUSOOT1: 'kInvalid'
-}
-
 ###########
 # Helpers #
 ###########
@@ -408,10 +399,6 @@ def warning(message):
   print(message)
   return ''
 
-# Muon showers: add filter function to get analysis type for use in templates
-def getAnalysisType(key):
-  return ANALYSIS_TYPES[key.getType()]
-
 def render(menu, template):
   module_dir = os.path.dirname(os.path.abspath(__file__))
   templates_dir = os.path.join(module_dir, 'templates')
@@ -440,7 +427,6 @@ def render(menu, template):
   j2_env.filters['getIndexCut'] = getIndexCut
   j2_env.filters['getScale'] = getScale
   j2_env.filters['getLookUpTable'] = getLookUpTable
-  j2_env.filters['getAnalysisType'] = getAnalysisType # Muon showers
   data = {
     "tmGrammar": tmGrammar,
     "tmEventSetup": tmEventSetup,

--- a/rate-estimation/menu2lib/templates/MenuTemplate.cc
+++ b/rate-estimation/menu2lib/templates/MenuTemplate.cc
@@ -317,9 +317,8 @@ PermutationFactory::cache_t PermutationFactory::cache_ = {};
   // Muon showers: associate the condition type and a given template;
   // it can be done for Centrality signals, as well
 #}
-  {# {% elif cond.getType() == tmEventSetup.MuonShower0, tmEventSetup.MuonShower1, tmEventSetup.MuonShowerOutOfTime0, tmEventSetup.MuonShowerOutOfTime1 %} #}
   {% elif cond.getType() in ShowerSignalTypes %}
-    {% include 'SignalsTemplate.cc' %}
+    {% include 'MuonShowerTemplate.cc' %}
 
   {% endif -%}
 {% endfor %}

--- a/rate-estimation/menu2lib/templates/MuonShowerTemplate.cc
+++ b/rate-estimation/menu2lib/templates/MuonShowerTemplate.cc
@@ -14,25 +14,30 @@ bool
 (L1Analysis::L1AnalysisL1UpgradeDataFormat* data)
 {
   bool pass = false;
-  {# Are signals in same bx? #}
-  if (data->{{ prefix }}Bx.at(0) == {{ object.getBxOffset() }})
-    {
-      {% if cond.getType() == tmEventSetup.MuonShower0 -%}
+
+  {# Is there at least one shower object? #}
+  if (data->nMuonShowers >= 1) {
+
+    {# Are signals in same bx? #}
+    if (data->{{ prefix }}Bx.at(0) == {{ object.getBxOffset() }})
+      {
+        {% if cond.getType() == tmEventSetup.MuonShower0 -%}
         if (data->{{ prefix }}OneNominal.at(0))
           {
             pass = true;
           }
-      {% elif cond.getType() == tmEventSetup.MuonShower1 -%}
+        {% elif cond.getType() == tmEventSetup.MuonShower1 -%}
         if (data->{{ prefix }}OneTight.at(0))
           {
             pass = true;
           }
-      {% elif cond.getType() == tmEventSetup.MuonShowerOutOfTime0 -%}
+        {% elif cond.getType() == tmEventSetup.MuonShowerOutOfTime0 -%}
         {# not implemented #}
-      {% elif cond.getType() == tmEventSetup.MuonShowerOutOfTime1 -%}
+        {% elif cond.getType() == tmEventSetup.MuonShowerOutOfTime1 -%}
         {# not implemented #}
-      {% endif -%}
-    }
+        {% endif -%}
+      }
+  }
   return pass;
 }
 {% endblock MuonShowerTemplate %}

--- a/rate-estimation/menu2lib/templates/MuonShowerTemplate.cc
+++ b/rate-estimation/menu2lib/templates/MuonShowerTemplate.cc
@@ -1,0 +1,39 @@
+{#
+    # @author: Sven Dildick (Rice University)
+ #}
+{# Template for muon showers #}
+{# See in: L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h #}
+
+{% block MuonShowerTemplate scoped %}
+{% import 'macros.jinja2' as macros %}
+{% set object = cond.getObjects()[0] %}
+{% set prefix = object | getPrefix  %}
+
+bool
+{{ cond.getName() }}
+(L1Analysis::L1AnalysisL1UpgradeDataFormat* data)
+{
+  bool pass = false;
+  {# Are signals in same bx? #}
+  if (data->{{ prefix }}Bx.at(0) == {{ object.getBxOffset() }})
+    {
+      {% if cond.getType() == tmEventSetup.MuonShower0 -%}
+        if (data->{{ prefix }}OneNominal.at(0))
+          {
+            pass = true;
+          }
+      {% elif cond.getType() == tmEventSetup.MuonShower1 -%}
+        if (data->{{ prefix }}OneTight.at(0))
+          {
+            pass = true;
+          }
+      {% elif cond.getType() == tmEventSetup.MuonShowerOutOfTime0 -%}
+        {# not implemented #}
+      {% elif cond.getType() == tmEventSetup.MuonShowerOutOfTime1 -%}
+        {# not implemented #}
+      {% endif -%}
+    }
+  return pass;
+}
+{% endblock MuonShowerTemplate %}
+{# eof #}

--- a/rate-estimation/menu2lib/templates/SignalsTemplate.cc
+++ b/rate-estimation/menu2lib/templates/SignalsTemplate.cc
@@ -1,5 +1,4 @@
-{# Template for signal type conditions like centrality or muon showers #}
-{# MuonShowerType from L1TNtuples: kInvalid, kOneNominal,kOneTight, kTwoLoose #}
+{# Template for signal type conditions like centrality #}
 {# See in: L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h #}
 
 {% block SignalsTemplate scoped %}


### PR DESCRIPTION
PR #62 had a design flaw, namely: it assumed that a shower could only be of 1 type (OneNominal, OneTight, TwoLoose). However, the implementation of the shower object in CMSSW is such that it is possible the shower is of multiple types. 

This PR should fix the behavior in the menu tools. It does hand-in-hand with this commit for the ntuples code https://github.com/cms-l1t-offline/cmssw/pull/951/commits/aefeb23b98ee49bac5adedf61a9739f47d022fe4