### PR TITLE
Mass/dR Implementation in New MenuTools

### DIFF
--- a/rate-estimation/menu2lib/menu2lib.py
+++ b/rate-estimation/menu2lib/menu2lib.py
@@ -158,7 +158,7 @@ def hasCorrelationCuts(condition):
 
   for cut in condition.getCuts():
     if cut.getCutType() in (tmEventSetup.DeltaEta, tmEventSetup.OvRmDeltaR, tmEventSetup.Mass, tmEventSetup.MassUpt,
-                            tmEventSetup.OvRmDeltaEta, tmEventSetup.DeltaR):
+                            tmEventSetup.OvRmDeltaEta, tmEventSetup.DeltaR, tmEventSetup.MassDeltaR):
       requireDeltaEta = True
 
   if requireDeltaEta:
@@ -349,6 +349,8 @@ def getLookUpTable(scaleMap, obj1, obj2):
   precisionMath = getPrecision(scaleMap, obj1, obj2, 'Math')
   precisionPt = getPrecision(scaleMap, obj1, obj2, 'MassPt')
 
+  precisionInvDeltaR = getPrecision(scaleMap, obj1, obj2, 'InverseDeltaRMath')
+
   has_deta = not (isVectorSum(obj1) or isVectorSum(obj2))
   convert = ((obj1.getType() != obj2.getType())
              and
@@ -373,6 +375,8 @@ def getLookUpTable(scaleMap, obj1, obj2):
     rc['COSH_DETA'] = "LUT_COSH_DETA_%s_%s" % (getObjectName(obj1), getObjectName(obj2))
     rc['PREC_DR'] = 2*precisionDelta
 
+    rc['PREC_INVDR'] = precisionInvDeltaR
+
   if convert:
     if obj1.getType() == tmEventSetup.Muon:
       rc['CONV_PHI'] = 'LUT_PHI_%s2%s' % (getObjectName(obj2), getObjectName(obj1))
@@ -386,6 +390,8 @@ def getLookUpTable(scaleMap, obj1, obj2):
         rc['ETA_OFFSET'] = 2**getScale(scaleMap, obj1, tmGrammar.ETA).getNbits()
   return rc
 
+def toMassDeltaR(value):
+  return "%.2f" % math.sqrt(2.*value)
 
 def toMass(value):
   return math.sqrt(2.*value)
@@ -419,6 +425,7 @@ def render(menu, template):
   j2_env.filters['warning'] = warning
   j2_env.filters['toMass'] = toMass
   j2_env.filters['toDeltaR'] = toDeltaR
+  j2_env.filters['toMassDeltaR'] = toMassDeltaR
   j2_env.filters['chkChgCor'] = chkChgCor
   j2_env.filters['getPrefix'] = getPrefix
   j2_env.filters['isMuon'] = isMuon

--- a/rate-estimation/menu2lib/templates/MenuTemplate.cc
+++ b/rate-estimation/menu2lib/templates/MenuTemplate.cc
@@ -290,7 +290,7 @@ PermutationFactory::cache_t PermutationFactory::cache_ = {};
       {% include 'CaloCaloCorrelationTemplate.cc' %}
     {% endif %}
 
-  {% elif cond.getType() in (tmEventSetup.InvariantMassUpt, ) %}
+  {% elif cond.getType() in (tmEventSetup.InvariantMassUpt, tmEventSetup.InvariantMassDeltaR) %}
     {% set objects = cond.getObjects() %}
     {% set combination = tmEventSetup.getObjectCombination(objects[0].getType(), objects[1].getType()) %}
     {% if combination == tmEventSetup.MuonMuonCombination %}

--- a/rate-estimation/menu2lib/templates/MuonMuonLUT.jinja2
+++ b/rate-estimation/menu2lib/templates/MuonMuonLUT.jinja2
@@ -52,4 +52,49 @@ const int LUT_MU_UPT[] = {
   {{x}}{% if not loop.last %},{% endif %}
 {%- endfor -%}
 };
+
+{# inverse deltaR #}
+const int prec_mu_mu_invdeltar = {{ scaleMap | getPrecisionByName('MU', 'MU', 'InverseDeltaRMath') }};
+const int prec_mu_mu_massdr = prec_mu_mu_mass + prec_mu_mu_invdeltar;
+
+{# const int iRSq = 0; #}
+{# const int jRSq = 0; #}
+{# const int iRSqmax = 227; #}
+{# const int jRSqmax = 145; #}
+{# const double tempRsq = 0.0; #}
+{# const double tempdiffeta = 0.02175; #}
+{# const double tempdiffphi = 0.02181661564992912; #}
+{# const double resolution = 0.5; #}
+{# const unsigned int precInvRsq = 0x5; #}
+
+
+{# const long long InvDeltaRSqLUT[iRSqmax][jRSqmax]; #}
+{# const double temp_InvDeltaRSq[iRSqmax][jRSqmax]; #}
+{# if (corrPar.corrCutType & 0x80) {  //Only build the 1/dR2 LUT if necessary #}
+{#   for (iRSq = 0; iRSq < iRSqmax; iRSq = iRSq + 1) { #}
+{#     for (jRSq = 0; jRSq < jRSqmax; jRSq = jRSq + 1) { #}
+{#       tempRsq = (tempdiffeta * iRSq) * (tempdiffeta * iRSq) + (tempdiffphi * jRSq) * (tempdiffphi * jRSq); #}
+{#       if (tempRsq > 0.0) { #}
+{#         temp_InvDeltaRSq[iRSq][jRSq] = 1.0 / tempRsq; #}
+{#         InvDeltaRSqLUT[iRSq][jRSq] = (long long)round(pow(10, precInvRsq) * temp_InvDeltaRSq[iRSq][jRSq]); #}
+{#       } else { #}
+{#         temp_InvDeltaRSq[iRSq][jRSq] = 0.0; #}
+{#         InvDeltaRSqLUT[iRSq][jRSq] = (long long)0; #}
+{#       } #}
+{#     } #}
+{#   } #}
+{# } #}
+
+
+
+{# const int LUT_INVDR_MU_MU[] = { #}
+{# {% for x in range -%} #}
+{# { #}
+{#   {% for y in mu_mu_invdelta[tmGrammar.INVERSE_DR] -%} #}
+{#     {{tempRsq}}{% if not loop.last %},{% endif %} #}
+{#   {%- endfor -%} #}
+{#   }{% if not loop.last %},{% endif %} #}
+{# {%- endfor -%} #}
+{# }; #}
+
 {# eof #}

--- a/rate-estimation/menu2lib/templates/macros.jinja2
+++ b/rate-estimation/menu2lib/templates/macros.jinja2
@@ -114,6 +114,17 @@
 {%- endmacro -%}
 
 {#
+ # set mass2 over delta R2
+ #}
+{%- macro setMass2DeltaR2(prefix0, prefix1, idx0, idx1, LUTS, iPi, useDelta=True) -%}
+    {{ setMass2(prefix0, prefix1, idx0, idx1, LUTS, iPi, useDelta) }}
+    const long long inversedR2 = {{LUTS.COS_DPHI}}[deltaIPhi];
+    {# dummy LUT for now #}
+    const long long mass2deltaR2 = mass2 * inversedR2;
+{%- endmacro -%}
+{# get actual LUT name #}
+
+{#
  # set mass3
  #}
 {%- macro setMass3(prefix0, prefix1, prefix2, idx0, idx1, idx2, LUTS, iPi, useDelta=True) -%}
@@ -143,7 +154,7 @@
     {
       const long long minimum = {{(cut.getMinimum().value * 10**precision) | int}}; // {{cut.getMinimum().value}} * 10^{{precision}}
       const long long maximum = {{(cut.getMaximum().value * 10**precision) | int}}; // {{cut.getMaximum().value}} * 10^{{precision}}
-      if (not ((minimum <= {{value}}) and ({{value}} <= maximum))) continue;
+      if (not ((minimum <= {{value}}) and (maximum == 0)) or ((minimum <= {{value}}) and ({{value}} <= maximum))) continue;      
     }
 {% endmacro -%}
 
@@ -286,6 +297,12 @@
     // {{ cut.getMinimum().value | toMass }} <= mass <= {{ cut.getMaximum().value | toMass}}
     {{ setMassUpt2(prefix, prefix, idx0, idx1, LUTS, iPi, False) }}
     {{ applyFunctionCut('mass2', cut, LUTS.PREC_MASS) }}
+
+  {% elif cut.getCutType() == tmEventSetup.MassDeltaR %}
+    // {{ cut.getMinimum().value | toMassDeltaR }} <= massdr <= {{ cut.getMaximum().value | toMassDeltaR}}
+    {{ setMass2DeltaR2(prefix, prefix, idx0, idx1, LUTS, iPi, False) }}
+    {{ applyFunctionCut('mass2deltaR2', cut, LUTS.PREC_INVDR) }}
+
 
   {% elif cut.getCutType() == tmEventSetup.ChargeCorrelation %}
     if (data->{{prefix}}Chg.at({{idx0}}) == 0) continue;  // charge valid bit not set


### PR DESCRIPTION
Mass/ΔR implementation in progress. Minimum only cut applied to applyFunctionCut macro and precision values for mass and 1/ΔR kept separate in order to easily match with how the emulator applies precision values.

Using a dummy LUT for now, but building of 1/ΔR2 LUT in progress and commented out in commit.

Elisa's comment on previous PR:
Reference PRs for the uGT emulator: 
- [PR#36499](https://github.com/cms-sw/cmssw/pull/36499) to central cmssw by Dragana;
- [PR#969](https://github.com/cms-l1t-offline/cmssw/pull/969) for the backport to the L1 Offline SW integration branch.