### PR TITLE
Inclusion of the displaced jet bit

### DIFF
--- a/rate-estimation/menu2lib/menu2lib.py
+++ b/rate-estimation/menu2lib/menu2lib.py
@@ -59,10 +59,6 @@ def getObjectName(key):
     tmEventSetup.MUS1: tmGrammar.MUS1,
     tmEventSetup.MUSOOT0: tmGrammar.MUSOOT0,
     tmEventSetup.MUSOOT1: tmGrammar.MUSOOT1
-    #tmEventSetup.MuonShower0: tmGrammar.MUS0,
-    #tmEventSetup.MuonShower1: tmGrammar.MUS1,
-    #tmEventSetup.MuonShowerOutOfTime0: tmGrammar.MUSOOT0,
-    #tmEventSetup.MuonShowerOutOfTime1: tmGrammar.MUSOOT1
   }[key.getType()]
 
 

--- a/rate-estimation/menu2lib/templates/macros.jinja2
+++ b/rate-estimation/menu2lib/templates/macros.jinja2
@@ -204,7 +204,7 @@
 {# set displaced jet bit #}
 {% elif cut.getCutType() == tmEventSetup.Displaced %}
         // displaced jet bit : {{"0x%x" % cut.getData() | int }}
-        if (not (({{"0x%x" % cut.getData() | int}} >> data->{{prefix}}Disp.at({{idx}})) & 1)) continue;
+        if (not (({{"0x%x" % cut.getData() | int}} >> data->{{prefix}}hwQual.at({{idx}})) & 1)) continue;
 
 {# set charge #}
 {% elif cut.getCutType() == tmEventSetup.Charge %}

--- a/rate-estimation/menu2lib/templates/macros.jinja2
+++ b/rate-estimation/menu2lib/templates/macros.jinja2
@@ -204,7 +204,7 @@
 {# set displaced jet bit #}
 {% elif cut.getCutType() == tmEventSetup.Displaced %}
         // displaced jet bit : {{"0x%x" % cut.getData() | int }}
-        if (not (({{"0x%x" % cut.getData() | int}} >> data->{{prefix}}HwQual.at({{idx}})) & 1)) continue;
+        if (not (({{"0x%x" % cut.getData() | int}} & data->{{prefix}}HwQual.at({{idx}})) & 1)) continue;
 
 {# set charge #}
 {% elif cut.getCutType() == tmEventSetup.Charge %}

--- a/rate-estimation/menu2lib/templates/macros.jinja2
+++ b/rate-estimation/menu2lib/templates/macros.jinja2
@@ -204,7 +204,7 @@
 {# set displaced jet bit #}
 {% elif cut.getCutType() == tmEventSetup.Displaced %}
         // displaced jet bit : {{"0x%x" % cut.getData() | int }}
-        if (not (({{"0x%x" % cut.getData() | int}} >> data->{{prefix}}hwQual.at({{idx}})) & 1)) continue;
+        if (not (({{"0x%x" % cut.getData() | int}} >> data->{{prefix}}HwQual.at({{idx}})) & 1)) continue;
 
 {# set charge #}
 {% elif cut.getCutType() == tmEventSetup.Charge %}

--- a/rate-estimation/menu2lib/templates/macros.jinja2
+++ b/rate-estimation/menu2lib/templates/macros.jinja2
@@ -201,6 +201,11 @@
         // impact parameter : {{"0x%x" % cut.getData() | int }}
         if (not (({{"0x%x" % cut.getData() | int}} >> data->{{prefix}}Dxy.at({{idx}})) & 1)) continue;
 
+{# set displaced jet bit #}
+{% elif cut.getCutType() == tmEventSetup.Displaced %}
+        // displaced jet bit : {{"0x%x" % cut.getData() | int }}
+        if (not (({{"0x%x" % cut.getData() | int}} >> data->{{prefix}}Disp.at({{idx}})) & 1)) continue;
+
 {# set charge #}
 {% elif cut.getCutType() == tmEventSetup.Charge %}
         // charge : {{ cut.getData() }}


### PR DESCRIPTION
Preliminary implementation of the displaced jet bit as an info for jet objects coming from the Calo Layer 2.
We have a 1-bit LUT where the value can be only 0-1.
Reference JIRA Ticket: [CMSLITDPG-963](https://its.cern.ch/jira/browse/CMSLITDPG-963).

**Open items**:
1) Name of the variable in the L1AnalysisL1UpgradeDataFormat --> final implementation in the emulator not available yet
2) Do we need to read a specific LUT like for the Iso or IP?