### PR TITLE
changed branch from 2544 to 2736

### DIFF
--- a/L1Ntuples/#README.md#
+++ b/L1Ntuples/#README.md#
@@ -1,0 +1,68 @@
+# L1Ntuples production recipe
+
+The following L1Ntuples recipe presents the latest snapshot used to create L1Ntuples
+for L1 menu studies.
+
+The targeted environment is Lxplus and assumes a standard session:
+```
+ssh -XY <username>@lxplus.cern.ch
+```
+
+Follow the below instructions in the given order to produce your own set of L1Ntuples
+on HTCondor.
+
+## 1. Environment setup
+Setup the environment according to the [official instructions](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TStage2Instructions#Environment_Setup_with_Integrati).
+
+```
+cmsrel CMSSW_12_3_0_pre6
+cd CMSSW_12_3_0_pre6/src
+cmsenv
+git cms-init
+git remote add cms-l1t-offline git@github.com:cms-l1t-offline/cmssw.git
+git fetch cms-l1t-offline l1t-integration-CMSSW_12_3_0_pre6
+git cms-merge-topic -u cms-l1t-offline:l1t-integration-v121.0-CMSSW_12_3_0_pre6
+git clone https://github.com/cms-l1t-offline/L1Trigger-L1TCalorimeter.git L1Trigger/L1TCalorimeter/data
+
+
+git cms-checkdeps -A -a
+
+
+scram b -j 8
+```
+
+## 2. Download the L1MenuTools/L1Ntuples code
+Clone this repository into your `$CMSSW_BASE/src/` folder. If you followed the
+instructions above, all you need to do is
+```
+git clone https://github.com/cms-l1-dpg/L1MenuTools.git
+```
+
+## 3. Customization of the submission file
+Go to the L1Ntuples subfolder
+```
+cd L1MenuTools/L1Ntuples
+```
+and customize the HTCondor submission script `condor_sub.py` according to your needs:
+- `eosDir`: output folder for batch jobs (user must have write permissions)
+- `nEvents`: number of events to process
+- `nJobs`: number of jobs to run
+
+
+## 4. Submit the production
+Some remaining steps before submitting:
+```
+scram b -j 8
+voms-proxy-init --voms cms --valid 168:00 -out $HOME/private/.proxy
+export X509_USER_PROXY=$HOME/private/.proxy
+```
+
+Finally, launch the production with
+```
+python condor_sub.py
+```
+
+## Additional notes about the current recipe
+- Input datasets: `/SingleNeutrino_Pt-2To20-gun/Run3Winter21DRMiniAOD-FlatPU30to80FEVT_SNB_112X_mcRun3_2021_realistic_v16-v2/GEN-SIM-DIGI-RAW`,
+`/SingleNeutrino_E10-gun/Run3Winter21DRMiniAOD-FlatPU30to80FEVT_SNB_112X_mcRun3_2021_realistic_v16-v2/GEN-SIM-DIGI-RAW`
+- It includes the PFA1' Filter (https://twiki.cern.ch/twiki/bin/viewauth/CMS/HcalPileupMitigation#PFA1_Filter)

--- a/L1Ntuples/.#README.md
+++ b/L1Ntuples/.#README.md
@@ -1,0 +1,1 @@
+bsahu@lxplus729.cern.ch.13959:1647000800

--- a/rate-estimation/README.md
+++ b/rate-estimation/README.md
@@ -90,7 +90,7 @@ Components have been provided to run a short test.
 ```bash
 ./testMenu2016 \
 -m menu/Prescale_2022_v0_1_1.csv -l ntuple/Run3_NuGun_MC_ntuples.list \
--o test -b 2544 --doPlotRate --doPlotEff --SelectCol 2E+34 \    
+-o test -b 2736 --doPlotRate --doPlotEff --SelectCol 2E+34 \    
 --doPrintPU --allPileUp --doReweightingRun3 --maxEvent 200000
 ```
 This will take only a few minutes and output test.csv, test.root, test.txt, and test_PU.txt into the results/ directory.

--- a/rate-estimation/docs/testMenu2016.md
+++ b/rate-estimation/docs/testMenu2016.md
@@ -17,7 +17,7 @@ Finally, run `make -j 4`.
 
 ## Test run
 Components (apart from menulib.hh and menulib.cc) are provided to run a short test.
-`./testMenu2016 -u menu/run_lumi.csv -m menu/Prescale_2018_v2_1_0_Col_2.0.txt -l ntuple/fill_7118_nanoDST_shifter_lxplus_test.list -o test -b 2544 --doPlotRate --doPlotEff --UseUnpackTree`
+`./testMenu2016 -u menu/run_lumi.csv -m menu/Prescale_2018_v2_1_0_Col_2.0.txt -l ntuple/fill_7118_nanoDST_shifter_lxplus_test.list -o test -b 2736 --doPlotRate --doPlotEff --UseUnpackTree`
 This will take only a few minutes and output test.csv, test.root, and test.txt into the results/ directory.
 Make sure you have set up the virtual environment as specified in the rate-estimation README, are in a CMSSW environment (ie- you have run `cmsenv`), and have run `make -j 4` since acquiring menulib.hh and menulib.cc.
 


### PR DESCRIPTION
I have tried to change the number of bunches from 2544 to 2736.
According to the updated LumiPOG scenarios, the number of bunches expected for LHC is a little bit higher, and this change has to be reflected in our rate studies.