### PR TITLE
change number of bunches from 2544 to 2736

### DIFF
--- a/rate-estimation/README.md
+++ b/rate-estimation/README.md
@@ -90,7 +90,7 @@ Components have been provided to run a short test.
 ```bash
 ./testMenu2016 \
 -m menu/Prescale_2022_v0_1_1.csv -l ntuple/Run3_NuGun_MC_ntuples.list \
--o test -b 2544 --doPlotRate --doPlotEff --SelectCol 2E+34 \    
+-o test -b 2736 --doPlotRate --doPlotEff --SelectCol 2E+34 \    
 --doPrintPU --allPileUp --doReweightingRun3 --maxEvent 200000
 ```
 This will take only a few minutes and output test.csv, test.root, test.txt, and test_PU.txt into the results/ directory.

--- a/rate-estimation/docs/testMenu2016.md
+++ b/rate-estimation/docs/testMenu2016.md
@@ -17,7 +17,7 @@ Finally, run `make -j 4`.
 
 ## Test run
 Components (apart from menulib.hh and menulib.cc) are provided to run a short test.
-`./testMenu2016 -u menu/run_lumi.csv -m menu/Prescale_2018_v2_1_0_Col_2.0.txt -l ntuple/fill_7118_nanoDST_shifter_lxplus_test.list -o test -b 2544 --doPlotRate --doPlotEff --UseUnpackTree`
+`./testMenu2016 -u menu/run_lumi.csv -m menu/Prescale_2018_v2_1_0_Col_2.0.txt -l ntuple/fill_7118_nanoDST_shifter_lxplus_test.list -o test -b 2736 --doPlotRate --doPlotEff --UseUnpackTree`
 This will take only a few minutes and output test.csv, test.root, and test.txt into the results/ directory.
 Make sure you have set up the virtual environment as specified in the rate-estimation README, are in a CMSSW environment (ie- you have run `cmsenv`), and have run `make -j 4` since acquiring menulib.hh and menulib.cc.
 

--- a/rate-estimation/include/L1Menu2016.C
+++ b/rate-estimation/include/L1Menu2016.C
@@ -101,7 +101,7 @@ bool L1Menu2016::InitConfig()
 {
   L1Config["SumJetET"]          = 0;
   L1Config["SumJetEta"]         = 999;
-  L1Config["nBunches"]          = 2544; //default for Run 2
+  L1Config["nBunches"]          = 2736; // Default for Run 2 = 2544 
   L1Config["doPlotRate"]        = 0;
   L1Config["doPlotEff"]         = 0;
   L1Config["doPlotTest"]        = 0;

--- a/rate-estimation/plots/CompPUDep.py
+++ b/rate-estimation/plots/CompPUDep.py
@@ -69,7 +69,7 @@ fit_max = 60
 
 # Setup: Run 2 2018
 freq = 11245.6
-nBunches = 2544
+nBunches = 2736 # default nBunches = 2544
 unit = "kHz"
 
 fitname = ROOT.TF1("fitname","[0]*x + [1]*x*x",0,70);


### PR DESCRIPTION
According to the latest recommendations from the LumiPOG for the LHC conditions at the beginning of Run 3, we expect a number of bunches a little bit higher (from 2544 to 2736) and an average PU of 47 (instead of PU 51-53 considered up to now for the rate studies).
This changes has to be reflected in our rate studies given that they affect the scaling of the L1 rates.