### PR TITLE
Ntuples production based on new 122X NuGun sample

### DIFF
--- a/L1Ntuples/NuGun_122X_cmsRun.sh
+++ b/L1Ntuples/NuGun_122X_cmsRun.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+echo "Starting job on " `date` #Date/time of start of job
+echo "Running on: `uname -a`" #Condor job is running on this node
+echo "System software: `cat /etc/redhat-release`" #Operating System on that node
+source /cvmfs/cms.cern.ch/cmsset_default.sh  ## if a bash script, use .sh instead of .csh
+### for case 1. EOS have the following line, otherwise remove this line in case 2.
+#Arguments 1)eosDir 2)jobName 3)rel 4)ProcId 5)nEvents 6)jobCfg 7)fileList 8) fileName
+cp ${1}${2}.tgz .
+tar -xf ${2}.tgz
+rm ${2}.tgz
+export $SCRAM_ARCH=slc7_amd64_gcc700
+cd ${3}/src/
+scramv1 b ProjectRename
+eval `scramv1 runtime -sh` # cmsenv is an alias not on the workers
+skipEvents=$((${4}*${5}))
+if (${4}==0) then
+line=$((${4}+1))
+else
+line=$((${4}*4+1))
+fi
+inFile1=$(awk "NR == ${line}" ${7})
+inFile2=$(awk "NR == (${line}+1)" ${7})
+inFile3=$(awk "NR == (${line}+2)" ${7})
+inFile4=$(awk "NR == (${line}+3)" ${7})
+inFile=$inFile1","$inFile2","$inFile3","$inFile4
+cmsRun L1MenuTools/L1Ntuples/${6} inputFile=${inFile} #maxEvents=${5} #skipEvents=${skipEvents}
+cp ${8} ${1}/${4}.root
+rm ${8}
+cd ${_CONDOR_SCRATCH_DIR}
+rm -rf ${3}

--- a/L1Ntuples/README.md
+++ b/L1Ntuples/README.md
@@ -20,7 +20,7 @@ cmsenv
 git cms-init
 git remote add cms-l1t-offline git@github.com:cms-l1t-offline/cmssw.git
 git fetch cms-l1t-offline l1t-integration-CMSSW_12_3_0_pre6
-git cms-merge-topic -u cms-l1t-offline:l1t-integration-v125.0
+git cms-merge-topic -u cms-l1t-offline:l1t-integration-v126.0
 git clone https://github.com/cms-l1t-offline/L1Trigger-L1TCalorimeter.git L1Trigger/L1TCalorimeter/data
 
 git cms-checkdeps -A -a
@@ -41,9 +41,12 @@ Go to the L1Ntuples subfolder
 cd L1MenuTools/L1Ntuples
 ```
 and customize the HTCondor submission script `condor_sub.py` according to your needs:
-- `eosDir`: output folder for batch jobs (user must have write permissions)
 - `nEvents`: number of events to process
-- `nJobs`: number of jobs to run corresponding to the number of files
+- `nJobs`: number of jobs for the splitting (corresponding to the number of files by default)
+- `fileList`: list of GEN-SIM-RAW files
+- `jobScript`: bash script containing the cmsRun command. NOTE: the default is `cmsRun.sh`, but if you need to run on the latest 122X NuGun sample, the number of files is very large so the script needs some changes (included in `NuGun_122X_cmsRun.sh`)for a successful condor submission
+- `eosDir`: output folder for batch jobs (user must have write permissions)
+- 'jobName': name of the directory created in eosDir and locally
 
 
 ## 4. Submit the production
@@ -60,6 +63,7 @@ python condor_sub.py
 ```
 
 ## Additional notes about the current recipe
+- It includes the PFA1' Filter (https://twiki.cern.ch/twiki/bin/viewauth/CMS/HcalPileupMitigation#PFA1_Filter)
 - Input datasets (120X): `/SingleNeutrino_Pt-2To20-gun/Run3Summer21DRPremix-SNB_120X_mcRun3_2021_realistic_v6-v2/GEN-SIM-DIGI-RAW`,
 `/SingleNeutrino_E-10-gun/Run3Summer21DRPremix-SNB_120X_mcRun3_2021_realistic_v6-v2/GEN-SIM-DIGI-RAW`
-- It includes the PFA1' Filter (https://twiki.cern.ch/twiki/bin/viewauth/CMS/HcalPileupMitigation#PFA1_Filter)
+- Input datasets (122X - Realistic PU distribution with an average PU of 48): `/SingleNeutrino_E-10-gun/Run3Winter22DR-L1TPU0to99FEVT_SNB_122X_mcRun3_2021_realistic_v9-v2/GEN-SIM-DIGI-RAW`

--- a/L1Ntuples/condor_sub.py
+++ b/L1Ntuples/condor_sub.py
@@ -6,13 +6,19 @@ ts = calendar.timegm(time.gmtime())
 
 fileName = "L1Ntuple.root"
 jobName = "menu_NuGun_12_3_X"
-jobCfg = "mc.py"
 jobScript = "cmsRun.sh"
+#jobScript = "NuGun_122X_cmsRun.sh" # New NuGun_E10 samples in 122X
+jobCfg = "mc.py"
 rel = "CMSSW_12_3_0_pre6"
 eosDir = "/eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/" + os.environ["USER"] + "/condor/" + jobName + "_" + str(ts) + "/"
 rootDir = os.environ["CMSSW_BASE"] + "/src/L1MenuTools/L1Ntuples/"
 jobDir = rootDir + jobName + "_" + str(ts) + "/"
 ret = 0
+
+## NOTE: For this submission, use NuGun_122X_cmsRun.sh as job script
+#fileList = rootDir + "newNuGun_mcRun3_realisticPU.list" 
+#nEvents = 11216000 # New NuGun_E10 samples in 122X                                                                   
+#nJobs = 7010       # New NuGun_E10 samples in 122X - Tot files: nJobs*4 (grouped in et of four for the submission) 
 
 fileList = rootDir + "nugun_Pt2-20.list" 
 nEvents = 1000000  #NuGun_Pt_2-20                                                                         
@@ -28,10 +34,8 @@ while ret == 0:
    ret = os.system("mkdir " + jobDir + "log/")
    ret = os.system("mkdir " + eosDir)
    ret = os.chdir(os.environ["CMSSW_BASE"]+"/../")
-   print('Tarballing ' + rel + "/ into " + jobName + ".tgz...")
    ret = os.system("tar --exclude='L1Ntuple.root' --exclude='ignore' --exclude='.git' " + 
                    "-zcf " + jobName + ".tgz " + rel)
-   print 'Done!'
    ret = os.system("mv " + jobName + ".tgz " + eosDir) 
    ret = os.chdir(rootDir)
 


### PR DESCRIPTION
Updates for the ntuples production based on the new large SingleNeutrino sample currently in production and partially available (around 10M out of 20M). See [here](https://cmsweb.cern.ch/das/request?view=list&input=%2FSingleNeutrino_E-10-gun%2FRun3Winter22DR-L1TPU0to99FEVT_SNB_122X_mcRun3_2021_realistic_v9-v2%2FGEN-SIM-DIGI-RAW) for details.

It includes a realistic pileup distribution with an average pileup larger that the previous 120X samples (<PU>=48). 