### PR TITLE
Added opposite sign correlation condition for triple muon seeds

### DIFF
--- a/rate-estimation/menu2lib/templates/macros.jinja2
+++ b/rate-estimation/menu2lib/templates/macros.jinja2
@@ -316,6 +316,17 @@
     // {{ cut.getMinimum().value | toMass }} <= mass <= {{ cut.getMaximum().value | toMass}}
     {{ setMass3(prefix, prefix, prefix, idx0, idx1, idx2, LUTS, iPi, False) }}
     {{ applyFunctionCut('mass3', cut, LUTS.PREC_MASS) }}
+  {% elif cut.getCutType() == tmEventSetup.ChargeCorrelation %}
+    if (data->{{prefix}}Chg.at({{idx0}}) == 0) continue;  // charge valid bit not set
+    if (data->{{prefix}}Chg.at({{idx1}}) == 0) continue;  // charge valid bit not set
+    if (data->{{prefix}}Chg.at({{idx2}}) == 0) continue;  // charge valid bit not set
+{% if cut.getData() == 'os' %}
+    // opposite-sign (os)
+    if (not(fabs(data->{{prefix}}Chg.at({{idx0}})+data->{{prefix}}Chg.at({{idx1}})+data->{{prefix}}Chg.at({{idx2}})) == fabs(data->{{prefix}}Chg.at({{idx0}})))) continue;
+{% elif cut.getData() == 'ls' %}
+    // like-sign (ls)
+    if ((fabs(data->{{prefix}}Chg.at({{idx0}})+data->{{prefix}}Chg.at({{idx1}})+data->{{prefix}}Chg.at({{idx2}})) == fabs(data->{{prefix}}Chg.at({{idx0}})))) continue;
+{% endif %}
   {% endif %}
   {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
Implemented sign correlation for new Triple Muon seeds. Details on the implementation are as follow:

1. L1 ntuples were produced following the recipe outlined in the twiki [1], using a custom test menu with Triple Mu OS seeds [2].
2. The cmsDriver command for producing the ntuples is as follows:
```
cmsDriver.py l1Ntuple -s RAW2DIGI --python_filename=data.py -n -1 --no_output --era=Run3 --data --conditions=auto:run3_data --customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleRAWEMU --customise=L1Trigger/Configuration/customiseUtils.L1TGlobalMenuXML --customise=L1Trigger/Configuration/customiseReEmul.L1TReEmulFromRAW --customise=L1Trigger/Configuration/customiseSettings.L1TSettingsToCaloParams_2022_v0_3 --filein=/store/data/Run2022E/EphemeralHLTPhysics0/RAW/v1/000/359/661/00000/355c33ec-6253-4590-bc11-94e0ce1b45be.root
```
3. The emulated uGT decision was obtained using the uGT_decision_counts scripts in MenuTools.
4. The charge correlation for 3 muons was implemented in /rate-estimation/menu2lib/templates/templates/macros.jinja2

The logic used is :
if (fabs(MuCharge(0)+MuCharge(1)+MuCharge(2))==fabs(MuCharge(0)) then the event passes

To compute the rate with rate-estimation, I use the following command (twiki [3]):
```
./testMenu2016 -m menu/TripleMu_v1.csv -l ntuple/TripleMuNtuples.list -o test -b 2748 --maxEvent -1 --SetNoPrescale --SelectCol 2E+34
```

A comparison of the counts from the uGT_decision_counts vs rate-estimation before and after the implementation is given here [4].

All the relevant items for validation and independent testing are provided here [5].


[1] https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TStage2Instructions#Custom_L1T_Menu
[2] https://sonawane.web.cern.ch/sonawane/private/L1studies/TripleMu_OS/L1Menu_TripleMu_test_forElisa_test.xml
[3] https://twiki.cern.ch/twiki/bin/viewauth/CMS/HowToL1TriggerMenu#4_Run_3_settings
[4] https://docs.google.com/spreadsheets/d/1Ye9CRdYPZ8d3jBEMr8yWaLsO5tLvKc_4t2N6djhZWPA/edit?usp=sharing
[5] https://sonawane.web.cern.ch/sonawane/private/L1studies/TripleMu_OS/