### PR TITLE
enable multiple processing of ntuples for rate estimations

### DIFF
--- a/rate-estimation/include/PreColumn.C
+++ b/rate-estimation/include/PreColumn.C
@@ -768,6 +768,7 @@ bool PreColumn::PrintRates(std::ostream &out, double scale)
       << std::setw(10)             << "L1Bit"
       << std::setw(L1NameLength+2) << "L1SeedName"
       << std::setw(10)             << "pre-scale"
+      << std::setw(10)             << "firecounts"
       << std::setw(10)             << "rate@13TeV"       << " +/- "
       << std::setw(20)             << "error_rate@13TeV"
       << std::setw(15)             << "pure@13TeV"       
@@ -785,6 +786,7 @@ bool PreColumn::PrintRates(std::ostream &out, double scale)
           << std::setw(10)             << seed.bit
           << std::setw(L1NameLength+2) << seed.name
           << std::setw(10)             << seed.prescale
+          << std::setw(10)             << seed.firecounts
           << std::setw(10)             << seed.firerate      << " +/- "
           << std::setw(20)             << seed.firerateerror
           << std::setw(15)             << seed.purerate      
@@ -805,6 +807,7 @@ bool PreColumn::PrintRates(std::ostream &out, double scale)
           << std::setw(10)             << seed.bit
           << std::setw(L1NameLength+2) << seed.name
           << std::setw(10)             << seed.prescale
+          << std::setw(10)             << seed.firecounts
           << std::setw(10)             << seed.firerate      << " +/- "
           << std::setw(20)             << seed.firerateerror
           << std::setw(15)             << seed.purerate      

--- a/rate-estimation/testMenu2016.py
+++ b/rate-estimation/testMenu2016.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+import os
+import re
+import pprint
+import subprocess
+from math import sqrt
+
+parser = argparse.ArgumentParser(
+    description='A wrapper around testMenu2016 program to enable parallel processing',
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
+
+parser.add_argument('--njobs', dest='njobs', type=int, default=16,
+                    help='number of parallel jobs to run')
+
+parser.add_argument('--just_analyze', dest='just_analyze', action='store_true',
+                    help='just analyze logs without processing ntuples')
+
+parser.add_argument('--name', dest='name', type=str, required=True,
+                    help='unique name of the test')
+
+parser.add_argument('-l', '--filelist', dest='filelist', type=str, required=True,
+                    help='input ntuple list')
+
+parser.add_argument('--tmp', dest='tmp', type=str, default="tmp/",
+                    help='path to a direcrtory where to store temporary files')
+
+args, unknown_args = parser.parse_known_args()
+
+def prepare_input():
+    if not args.filelist:
+        raise Exception("filelist is not provided")
+
+    files = []
+    with open(args.filelist) as f:
+        for file in f.readlines():
+            files.append(file.strip())
+    nfiles = len(files)
+    print("Number of files: %u" % nfiles)
+
+    filelists = []
+
+    nfiles_per_job = int(nfiles / args.njobs)
+    if nfiles_per_job * args.njobs < nfiles:
+        nfiles_per_job += 1
+
+    index = 0
+    for i in range(0, nfiles, nfiles_per_job):
+        filename = "%s-%02u.list" % (args.name, index)
+        index += 1
+        with open("%s/%s" % (args.tmp, filename), "w") as f:
+            for file in files[i:i+nfiles_per_job]:
+                f.write("%s\n" % file)
+        filelists.append(filename)
+    
+    return filelists
+
+def process_ntuples(filelists):
+    processes = []
+    
+    for i in range(args.njobs):
+        command = "./testMenu2016 -l %s/%s -o %s-%u %s > %s/%s-%u.log 2>&1" % (
+            args.tmp, filelists[i], args.name, i, " ".join(unknown_args),
+            args.tmp, args.name, i)
+        print(command)
+        processes.append(subprocess.Popen(command, shell=True))
+        print("Started subprocess with id: %s" % processes[i].pid)
+
+    print("Waiting for all jobs to finish")
+    # Check if all jobs finished
+    for p in processes:
+        if p.poll() is None:
+            p.wait()
+
+
+def report_results():
+    yields = dict()
+    nEvents = 0
+    nZBEvents = 0
+    nBunches = 2450
+    nFiredTotal = 0
+
+    entries = os.scandir(args.tmp)
+    max_len = 0
+    n = 0
+    for i in entries:
+        if re.search(r'^%s-\d+.log$' % args.name, i.name):
+            n += 1
+            with open(args.tmp + "/" + i.name) as f:
+                scale = None
+                for line in f.read().splitlines():
+                    # print(line)
+                    match = re.search(r'^(\d+)\s+(L1_\S+)\s+\d+\s+(\d+)\s+(\S+)',
+                                      line)
+                    if match:
+                        trigger = match.group(2)
+                        if trigger not in yields:
+                            if len(trigger) > max_len:
+                                max_len = len(trigger)
+                            yields[trigger] = 0
+                        yields[trigger] += int(match.group(3))
+                        if float(match.group(4)) > 0:
+                            scale = int(match.group(3))/float(match.group(4))
+                    match = re.search(r'Total Event:\s+(\d+)', line)
+                    if match:
+                        nEvents += int(match.group(1))
+                    match = re.search(r'nZeroBiasevents =\s+(\d+)', line)
+                    if match:
+                        nZBEvents += int(match.group(1))
+                    match = re.search(r'Total rate  =\s+(\S+)', line)
+                    if match and scale is not None:
+                        nFiredTotal += float(match.group(1)) * scale * 1e3
+
+    print("Number of log files found: %u" % n)
+    print("Total Event: %u" % nEvents)
+    print("Total ZB Event: %u" % nZBEvents)
+
+    if nZBEvents:
+        scale = 11246. * nBunches / nZBEvents
+
+        print("Total rate: %5.2f +/- %5.2f kHz" % (nFiredTotal * scale / 1e3,
+                                                   sqrt(nFiredTotal) * scale / 1e3))
+
+        for entry in sorted(yields):
+            format = "% -" + str(max_len + 1) + "s: %4u %5.2f +/- %5.2f kHz"
+            print(format % (entry, yields[entry], yields[entry] * scale / 1e3,
+                            sqrt(yields[entry]) * scale / 1e3))
+
+
+# print(sys.argv)
+# print(unknown)
+
+if __name__ == "__main__":
+    if not os.path.exists(args.tmp):
+        raise Exception("Path doesn't exists: %s" % args.tmp)
+
+    print(unknown_args)
+
+    if not args.just_analyze:
+        filelists = prepare_input()
+    
+        process_ntuples(filelists)
+
+    report_results()


### PR DESCRIPTION
Added a new python script and modified the source code a bit to allow for parallel processing on ntuples and rate estimation based on the logs produced during the processing. The script is meant to be use on a multi-core machine. The format of the merged output differs from the one used in the main program.

In order to use the script you call it instead of the main program giving the same arguments that you would give to `testMenu16`.  To see new parameters needed by script, run `./testMenu2016.py -h ` or `python3 testMenu2016.py -h`.

Example:
`./testMenu2016.py --njobs 32 --name test -l ntuple/2022EphZB_run362439_126X.list -m L1Menu_Collisions2022_v1_4_0-13.6TeV_baseline_for_Run2023_with_new_dimuon_seeds_max.csv -u menu/run_lumi.csv -b 2450 --doPlotRate --doPlotEff --maxEvent 1000000 --SelectCol 2.00E+34 --SetL1AcceptPS 1`

The example runs for about 20 mins on a machine with 16 real and 16 hyperthreaded cores.