### PR TITLE
Preliminary parallel rate estimation

### DIFF
--- a/rate-estimation/README.md
+++ b/rate-estimation/README.md
@@ -19,6 +19,16 @@ Requires:
 * Prescale table
 See [docs/testMenu2016.md]() for more information.
 
+#### testMenu2016.py
+Parallel version of `testMenu2016`.
+It allocates several CPU cores and starts the default rate estimation with with a subset of data.
+In the end the outputs of the different jobs are combined and a joined output is presented.
+
+*Important* this is a preliminary version that does only support Prescales of 0 or 1.
+Make sure that the selected prescale column only contains those values otherwise it will fail.
+This code is only to get a fast but rough estimate of the L1 rate, because prescaled seeds need to be excluded.
+For further details on the parameters, see below.
+
 #### menu2lib/menu2lib.py
 Converts the XML menu to C++ to be used in testMenu2016 for rate estimation.
 Do not run cmsenv before running this.
@@ -125,6 +135,17 @@ The arguments that you can use are as follows:
 |`--PrescalePrecision` | Select the prescale precision factor e.g. for 100 (=10^2) the prescales are represented with 2 decimal places |
 
 Running `./testMenu2016 --help` will show all arguments with a brief description. Also see [docs/testMenu2016.md]().
+
+#### Arguments for parallel version
+Most of the arguments of the rate estimation code (above) can be used exactly as in the single threaded version, because they are just passed to the parallel version.
+The following arguments are specific for the parallel version:
+
+|Option | Description |
+|-------|-------------|
+|`--njobs` | number of parallel jobs to run |
+|`--just_analyze` | just analyze logs without processing ntuples |
+|`--name` | unique name of the test, replaces the option `-o` of the original code |
+|`--tmp` | path to an existing direcrtory where to store temporary files |
 
 #### Important note:
 Please remember that when you use the --SelectCol option, you just select a specific PS column from the table which contains the information about which seeds are prescaled or unprescaled and about the prescale values. It does not allow to select a certain luminosity. In order to look at rates using a specific luminosity scenario, you would need to use lumi-range-skimmed datasets or to select a specific pileup window when running the rates. 

--- a/rate-estimation/include/PreColumn.C
+++ b/rate-estimation/include/PreColumn.C
@@ -768,6 +768,7 @@ bool PreColumn::PrintRates(std::ostream &out, double scale)
       << std::setw(10)             << "L1Bit"
       << std::setw(L1NameLength+2) << "L1SeedName"
       << std::setw(10)             << "pre-scale"
+      << std::setw(10)             << "firecounts"
       << std::setw(10)             << "rate@13TeV"       << " +/- "
       << std::setw(20)             << "error_rate@13TeV"
       << std::setw(15)             << "pure@13TeV"       
@@ -785,6 +786,7 @@ bool PreColumn::PrintRates(std::ostream &out, double scale)
           << std::setw(10)             << seed.bit
           << std::setw(L1NameLength+2) << seed.name
           << std::setw(10)             << seed.prescale
+          << std::setw(10)             << seed.firecounts
           << std::setw(10)             << seed.firerate      << " +/- "
           << std::setw(20)             << seed.firerateerror
           << std::setw(15)             << seed.purerate      
@@ -805,6 +807,7 @@ bool PreColumn::PrintRates(std::ostream &out, double scale)
           << std::setw(10)             << seed.bit
           << std::setw(L1NameLength+2) << seed.name
           << std::setw(10)             << seed.prescale
+          << std::setw(10)             << seed.firecounts
           << std::setw(10)             << seed.firerate      << " +/- "
           << std::setw(20)             << seed.firerateerror
           << std::setw(15)             << seed.purerate      

--- a/rate-estimation/testMenu2016.py
+++ b/rate-estimation/testMenu2016.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+import os
+import re
+import pprint
+import subprocess
+from math import sqrt
+
+parser = argparse.ArgumentParser(
+    description='A wrapper around testMenu2016 program to enable parallel processing',
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
+
+parser.add_argument('--njobs', dest='njobs', type=int, default=16,
+                    help='number of parallel jobs to run')
+
+parser.add_argument('--just_analyze', dest='just_analyze', action='store_true',
+                    help='just analyze logs without processing ntuples')
+
+parser.add_argument('--name', dest='name', type=str, required=True,
+                    help='unique name of the test')
+
+parser.add_argument('-l', '--filelist', dest='filelist', type=str, required=True,
+                    help='input ntuple list')
+
+parser.add_argument('--tmp', dest='tmp', type=str, default="tmp/",
+                    help='path to a direcrtory where to store temporary files')
+
+args, unknown_args = parser.parse_known_args()
+
+def prepare_input():
+    if not args.filelist:
+        raise Exception("filelist is not provided")
+
+    files = []
+    with open(args.filelist) as f:
+        for file in f.readlines():
+            files.append(file.strip())
+    nfiles = len(files)
+    print("Number of files: %u" % nfiles)
+
+    filelists = []
+
+    nfiles_per_job = int(nfiles / args.njobs)
+    if nfiles_per_job * args.njobs < nfiles:
+        nfiles_per_job += 1
+
+    index = 0
+    for i in range(0, nfiles, nfiles_per_job):
+        filename = "%s-%02u.list" % (args.name, index)
+        index += 1
+        with open("%s/%s" % (args.tmp, filename), "w") as f:
+            for file in files[i:i+nfiles_per_job]:
+                f.write("%s\n" % file)
+        filelists.append(filename)
+    
+    return filelists
+
+def process_ntuples(filelists):
+    processes = []
+    
+    for i in range(args.njobs):
+        command = "./testMenu2016 -l %s/%s -o %s-%u %s > %s/%s-%u.log 2>&1" % (
+            args.tmp, filelists[i], args.name, i, " ".join(unknown_args),
+            args.tmp, args.name, i)
+        print(command)
+        processes.append(subprocess.Popen(command, shell=True))
+        print("Started subprocess with id: %s" % processes[i].pid)
+
+    print("Waiting for all jobs to finish")
+    # Check if all jobs finished
+    for p in processes:
+        if p.poll() is None:
+            p.wait()
+
+
+def report_results():
+    yields = dict()
+    nEvents = 0
+    nZBEvents = 0
+    nBunches = 2450
+    nFiredTotal = 0
+
+    entries = os.scandir(args.tmp)
+    max_len = 0
+    n = 0
+    for i in entries:
+        if re.search(r'^%s-\d+.log$' % args.name, i.name):
+            n += 1
+            with open(args.tmp + "/" + i.name) as f:
+                scale = None
+                for line in f.read().splitlines():
+                    # print(line)
+                    match = re.search(r'^(\d+)\s+(L1_\S+)\s+\d+\s+(\d+)\s+(\S+)',
+                                      line)
+                    if match:
+                        trigger = match.group(2)
+                        if trigger not in yields:
+                            if len(trigger) > max_len:
+                                max_len = len(trigger)
+                            yields[trigger] = 0
+                        yields[trigger] += int(match.group(3))
+                        if float(match.group(4)) > 0:
+                            scale = int(match.group(3))/float(match.group(4))
+                    match = re.search(r'Total Event:\s+(\d+)', line)
+                    if match:
+                        nEvents += int(match.group(1))
+                    match = re.search(r'nZeroBiasevents =\s+(\d+)', line)
+                    if match:
+                        nZBEvents += int(match.group(1))
+                    match = re.search(r'Total rate  =\s+(\S+)', line)
+                    if match and scale is not None:
+                        nFiredTotal += float(match.group(1)) * scale * 1e3
+
+    print("Number of log files found: %u" % n)
+    print("Total Event: %u" % nEvents)
+    print("Total ZB Event: %u" % nZBEvents)
+
+    if nZBEvents:
+        scale = 11246. * nBunches / nZBEvents
+
+        print("Total rate: %5.2f +/- %5.2f kHz" % (nFiredTotal * scale / 1e3,
+                                                   sqrt(nFiredTotal) * scale / 1e3))
+
+        for entry in sorted(yields):
+            format = "% -" + str(max_len + 1) + "s: %4u %5.2f +/- %5.2f kHz"
+            print(format % (entry, yields[entry], yields[entry] * scale / 1e3,
+                            sqrt(yields[entry]) * scale / 1e3))
+
+
+# print(sys.argv)
+# print(unknown)
+
+if __name__ == "__main__":
+    if not os.path.exists(args.tmp):
+        raise Exception("Path doesn't exists: %s" % args.tmp)
+
+    print(unknown_args)
+
+    if not args.just_analyze:
+        filelists = prepare_input()
+    
+        process_ntuples(filelists)
+
+    report_results()

--- a/rate-estimation/testMenu2016.py
+++ b/rate-estimation/testMenu2016.py
@@ -56,6 +56,8 @@ def prepare_input():
     files = []
     with open(args.filelist) as f:
         for file in f.readlines():
+            if file[0] == '#' or file.strip() == '': #comment line or empty line
+                continue
             files.append(file.strip())
     nfiles = len(files)
     print("Number of files: %u" % nfiles)
@@ -63,17 +65,18 @@ def prepare_input():
     filelists = []
 
     nfiles_per_job = int(nfiles / args.njobs)
-    if nfiles_per_job * args.njobs < nfiles:
-        nfiles_per_job += 1
+    nfiles_rest = nfiles % args.njobs
+    step_files = [0, nfiles_rest * (nfiles_per_job + 1), nfiles]
 
     index = 0
-    for i in range(0, nfiles, nfiles_per_job):
-        filename = "%s-%02u.list" % (args.name, index)
-        index += 1
-        with open("%s/%s" % (args.tmp, filename), "w") as f:
-            for file in files[i:i+nfiles_per_job]:
-                f.write("%s\n" % file)
-        filelists.append(filename)
+    for j in range(2):
+        for i in range(step_files[j], step_files[j + 1], nfiles_per_job + 1 -j):
+            filename = "%s-%02u.list" % (args.name, index)
+            index += 1
+            with open("%s/%s" % (args.tmp, filename), "w") as f:
+                for file in files[i:i+nfiles_per_job + 1 - j]:
+                    f.write("%s\n" % file)
+            filelists.append(filename)
     
     return filelists
 

--- a/rate-estimation/testMenu2016.py
+++ b/rate-estimation/testMenu2016.py
@@ -6,6 +6,8 @@ import re
 import pprint
 import subprocess
 from math import sqrt
+import csv
+import numpy as np
 
 parser = argparse.ArgumentParser(
     description='A wrapper around testMenu2016 program to enable parallel processing',
@@ -26,8 +28,26 @@ parser.add_argument('-l', '--filelist', dest='filelist', type=str, required=True
 
 parser.add_argument('--tmp', dest='tmp', type=str, default="tmp/",
                     help='path to a direcrtory where to store temporary files')
+parser.add_argument('-m', '--menufile', dest = 'menufile', type = str, required = True,
+                    help = 'set the input menu')
+parser.add_argument('--SelectCol', dest = 'SelectCol', type = str, required = True,
+                    help = 'Select prescale column from input csv menu')
+parser.add_argument('-b', '--nBunches', dest = 'nBunches', type = int, default = 2748,
+                    help = 'set number of bunches')
 
 args, unknown_args = parser.parse_known_args()
+
+
+def check_prescales():
+    """Check whether the requested prescale column contains prescale that are neither 1 or 0"""
+    header = np.loadtxt(args.menufile, dtype = str, delimiter = ',', max_rows = 1)  # read the header from the prescale table
+    col_number = np.argwhere(header == args.SelectCol)  # get the number of the selected ps column
+    if len(col_number) != 1:  # there should be exactly one column that matches the selected one
+        raise ValueError(f'The prescale column {args.SelectCol} is not found in the prescale table (or it was found several times).')
+    col_number = int(col_number)
+    col = np.loadtxt(args.menufile, delimiter = ',', skiprows = 1, usecols = col_number)  # get the values of the selected ps column
+    n_wrong_ps = ((col != 1) & (col != 0)).sum()  # prescales are only allowed to be 1 or 0, count the number of wrong prescales
+    return n_wrong_ps == 0
 
 def prepare_input():
     if not args.filelist:
@@ -61,8 +81,8 @@ def process_ntuples(filelists):
     processes = []
     
     for i in range(args.njobs):
-        command = "./testMenu2016 -l %s/%s -o %s-%u %s > %s/%s-%u.log 2>&1" % (
-            args.tmp, filelists[i], args.name, i, " ".join(unknown_args),
+        command = "./testMenu2016 -l %s/%s -o %s-%u -m %s --SelectCol %s -b %u %s > %s/%s-%u.log 2>&1" % (
+            args.tmp, filelists[i], args.name, i, args.menufile, args.SelectCol, args.nBunches, " ".join(unknown_args),
             args.tmp, args.name, i)
         print(command)
         processes.append(subprocess.Popen(command, shell=True))
@@ -76,10 +96,10 @@ def process_ntuples(filelists):
 
 
 def report_results():
-    yields = dict()
+    yields = []
     nEvents = 0
     nZBEvents = 0
-    nBunches = 2450
+    nBunches = args.nBunches
     nFiredTotal = 0
 
     entries = os.scandir(args.tmp)
@@ -90,25 +110,29 @@ def report_results():
             n += 1
             with open(args.tmp + "/" + i.name) as f:
                 scale = None
+                j = 0
                 for line in f.read().splitlines():
                     # print(line)
-                    match = re.search(r'^(\d+)\s+(L1_\S+)\s+\d+\s+(\d+)\s+(\S+)',
+                    match = re.search(r'^(\d+)\s+(L1_\S+)\s+(\d+)\s+(\d+)\s+(\S+)',
                                       line)
                     if match:
-                        trigger = match.group(2)
-                        if trigger not in yields:
+                        if n == 1:
+                            trigger_bit = match.group(1)
+                            trigger = match.group(2)
+                            prescale = match.group(3)
                             if len(trigger) > max_len:
                                 max_len = len(trigger)
-                            yields[trigger] = 0
-                        yields[trigger] += int(match.group(3))
-                        if float(match.group(4)) > 0:
-                            scale = int(match.group(3))/float(match.group(4))
+                            yields.append([trigger_bit, trigger, prescale, 0.0, 0.0, 0])  # append a list that contains (or will contain) the trigger bit, the trigger name, the prescale, the trigger rate, the rate error and the total firecounts
+                        yields[j][5] += int(match.group(4))  # read the firecounts and add them to the counts from previous files
+                        if float(match.group(5)) > 0:
+                            scale = int(match.group(4))/float(match.group(5))
+                        j+=1
                     match = re.search(r'Total Event:\s+(\d+)', line)
                     if match:
-                        nEvents += int(match.group(1))
+                        nEvents += int(match.group(1))  # read the total number of events
                     match = re.search(r'nZeroBiasevents =\s+(\d+)', line)
                     if match:
-                        nZBEvents += int(match.group(1))
+                        nZBEvents += int(match.group(1))  # read the number of ZB events
                     match = re.search(r'Total rate  =\s+(\S+)', line)
                     if match and scale is not None:
                         nFiredTotal += float(match.group(1)) * scale * 1e3
@@ -123,10 +147,41 @@ def report_results():
         print("Total rate: %5.2f +/- %5.2f kHz" % (nFiredTotal * scale / 1e3,
                                                    sqrt(nFiredTotal) * scale / 1e3))
 
-        for entry in sorted(yields):
-            format = "% -" + str(max_len + 1) + "s: %4u %5.2f +/- %5.2f kHz"
-            print(format % (entry, yields[entry], yields[entry] * scale / 1e3,
-                            sqrt(yields[entry]) * scale / 1e3))
+        for entry in yields:
+            entry[3] = round(entry[5] * scale, 2)
+            entry[4] = round(sqrt(entry[5]) * scale, 2)
+            #format = "% -" + str(max_len + 1) + "s: %4u %5.2f +/- %5.2f kHz"
+            #print(format % (entry, yields[entry], yields[entry] * scale / 1e3,
+                            #sqrt(yields[entry]) * scale / 1e3))
+        
+        with open(f'results/{args.name}_combined.csv', 'w') as csv_file:
+            csv_writer = csv.writer(csv_file, delimiter = ',')
+            csv_writer.writerow(['L1Bit', 'L1SeedName', 'pre-scale0', 'rate0', 'error_rate0', 'firecounts'])
+            csv_writer.writerows(yields)
+            csv_writer.writerow([])
+            csv_writer.writerow([])
+            csv_writer.writerow([])
+            csv_writer.writerow([9999, 'Total rate', 1, round(nFiredTotal * scale / 1e3, 2), round(sqrt(nFiredTotal) * scale / 1e3, 2), round(nFiredTotal)])
+        
+        with open(f'results/{args.name}_combined.txt', 'w') as txt_file:
+            # print the header
+            seed_name_len = max_len + 2
+            print_str = f'{"L1Bit":10}{"L1SeedName":{seed_name_len}}{"pre-scale":10}{"firecounts":15}{"rate@13TeV":10} +/- {"error_rate@13TeV":20}{"passevts@13TeV":15}'
+            print(print_str)
+            txt_file.write(f'{print_str}\n')
+            
+            # print the values (for each trigger
+            for entry in yields:
+                print_str = f'{entry[0]:10}{entry[1]:{seed_name_len}}{entry[2]:10}{entry[5]:<15}{entry[3]:<10} +/- {entry[4]:<20}{entry[5]:<15}'
+                print(print_str)
+                txt_file.write(f'{print_str}\n')
+            
+            print('')
+            txt_file.write('\n')
+            
+            print_str = "Total rate: %5.2f +/- %5.2f kHz" % (nFiredTotal * scale / 1e3, sqrt(nFiredTotal) * scale / 1e3)
+            print(print_str)
+            txt_file.write(f'{print_str}\n')
 
 
 # print(sys.argv)
@@ -139,6 +194,8 @@ if __name__ == "__main__":
     print(unknown_args)
 
     if not args.just_analyze:
+        if not check_prescales():
+            raise Exception(f'The prescale column {args.SelectCol} of the table {args.menufile} contains prescales that are neither 1 nor 0. This script is an intermediate solution and only supports unprescaled or deactivated trigger seeds. Please decide for each prescaled seed whether you want to deactivate it or use it unprescaled and change the prescale table correspondingly')
         filelists = prepare_input()
     
         process_ntuples(filelists)


### PR DESCRIPTION
This is based on [this pull request](https://github.com/cms-l1-dpg/L1MenuTools/pull/99) by Dima. It is a preliminary solution to have parallel rate estimation on a multi core machine available. A python script can be executed with parameters that are very similar to the ones of the default single threaded rate estimation. The python script internally starts several processes of the single threaded version and divides the ntuple files amongst the sub processes. In the end it combines the output of the subrocesses. The output format differs from the original one but it is very similar.
Sadly this only allowes a rough estimate of the rates, because prescaled seeds are not supported, seeds are either activated or deactivated. Furthermore it only calculates the total rate for each seed but not the pure and proportional rate.