### PR TITLE
Bugfix SetNoPrescale didn't wor for prescaled seeds

### DIFF
--- a/rate-estimation/include/L1Menu2016.C
+++ b/rate-estimation/include/L1Menu2016.C
@@ -598,13 +598,14 @@ bool L1Menu2016::ReadMenuTXT(std::ifstream &menufile)
     temp.bit = bit;
     temp.comment = comline;
     temp.prescale = prescale;
-    temp.prescale_discret = int(std::round(prescale * L1Config["PrescalePrecision"]));
 
     if (L1Config["doCompuGT"] || L1Config["SetNoPrescale"])
       temp.prescale = 1;
 
     if (L1Config["IgnorePrescale"] && temp.prescale > 1 )
       temp.prescale = 0;
+
+    temp.prescale_discret = int(std::round(temp.prescale * L1Config["PrescalePrecision"]));
 
     if (pog.length() != 0)
       temp.POG = TokenGroups(pog);
@@ -761,7 +762,6 @@ bool L1Menu2016::ReadMenuCSV(std::ifstream &menufile)
         try
         {
           temp.prescale = boost::lexical_cast<double>(it);
-          temp.prescale_discret = int(std::round(temp.prescale * L1Config["PrescalePrecision"]));
         }
         catch (const boost::bad_lexical_cast &)
         {
@@ -791,6 +791,8 @@ bool L1Menu2016::ReadMenuCSV(std::ifstream &menufile)
 
       if (L1Config["IgnorePrescale"] && temp.prescale > 1 )
         temp.prescale = 0;
+      
+      temp.prescale_discret = int(std::round(temp.prescale * L1Config["PrescalePrecision"]));
     }
 
     if (writefiles)


### PR DESCRIPTION
Elisa figured out that `--SetNoPrescale` didn't work correctly. `--SetNoPrescale` is supposed to set all prescales to 1. For prescaled seeds the prescale wasn't set to 1 it continued using the original value even though the prescale printed in the output files was 1.
The `prescale` variable was correctly set to 1 but for the computation the `prescale_discrete` was used which was introduced for handling fractional prescales. The `prescale_discrete` can be computed using the `prescale`. The computation of `prescale_discrete` was done before `prescale` is set to 1 in case of `--SetNoPrescale` or is set to 0 in case of `--IgnorePrescale`. The computation of `prescale_discrete` is now moved behind these optional changes of `prescale`. `--SetNoPrescale` and `--IgnorePrescale` should work correctly now.